### PR TITLE
Add App widget and onboarding screen

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'onboarding_screen.dart';
+
+/// Root app widget
+class App extends StatelessWidget {
+  const App({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Habit Tracker',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      darkTheme: ThemeData.dark(),
+      themeMode: ThemeMode.system,
+      home: const OnboardingScreen(),
+      routes: {
+        '/home': (context) => const HomeScreen(),
+      },
+    );
+  }
+}
+
+/// Placeholder home screen used in the routes map
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(child: Text('Home Screen')),
+    );
+  }
+}

--- a/lib/onboarding_screen.dart
+++ b/lib/onboarding_screen.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+
+/// Simple onboarding screen placeholder
+class OnboardingScreen extends StatelessWidget {
+  const OnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Onboarding')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.pushNamed(context, '/home');
+          },
+          child: const Text('Continue'),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `App` widget and route to `/home`
- add placeholder onboarding screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876184d71488329ae00e2a31535edf3