### PR TITLE
Add HomeScreen with empty state UI

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'onboarding_screen.dart';
+import 'features/home/home_screen.dart';
 
 /// Root app widget
 class App extends StatelessWidget {
@@ -20,14 +21,3 @@ class App extends StatelessWidget {
   }
 }
 
-/// Placeholder home screen used in the routes map
-class HomeScreen extends StatelessWidget {
-  const HomeScreen({super.key});
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(child: Text('Home Screen')),
-    );
-  }
-}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+
+/// Home screen shown when the user has completed onboarding.
+///
+/// Displays an empty state prompting the user to add their first habit.
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  /// Navigates to the add habit flow.
+  void _goToAddHabit(BuildContext context) {
+    Navigator.of(context).pushNamed('/add_habit');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const purple = Color(0xFF8A2BE2);
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF121212),
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.settings, color: Colors.white),
+          onPressed: () {},
+        ),
+        title: RichText(
+          text: const TextSpan(
+            style: TextStyle(
+              fontWeight: FontWeight.bold,
+              fontSize: 20,
+              fontFamily: 'Roboto',
+            ),
+            children: [
+              TextSpan(text: 'Habit', style: TextStyle(color: Colors.white)),
+              TextSpan(text: 'Kit', style: TextStyle(color: purple)),
+            ],
+          ),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.bar_chart, color: Colors.white),
+            onPressed: () {},
+          ),
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline, color: Colors.white),
+            onPressed: () => _goToAddHabit(context),
+          ),
+        ],
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 80,
+                height: 80,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.white.withOpacity(0.1),
+                ),
+                child: const Icon(Icons.add, color: Colors.white, size: 40),
+              ),
+              const SizedBox(height: 24),
+              const Text(
+                'No habit found',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'Create a new habit to track your progress',
+                textAlign: TextAlign.center,
+                style: TextStyle(color: Colors.white70),
+              ),
+              const SizedBox(height: 32),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: purple,
+                    foregroundColor: Colors.white,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(30),
+                    ),
+                  ),
+                  onPressed: () => _goToAddHabit(context),
+                  child: const Text('Get started'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create `HomeScreen` in `features/home/home_screen.dart`
- link new screen from `app.dart` and remove placeholder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68761bf19cf48329acc61c8cc483f22a