### PR TITLE
Add habit creation feature

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'features/onboarding/onboarding_screen.dart';
 import 'features/home/home_screen.dart';
+import 'features/habits/add_edit_habit_screen.dart';
+import 'features/habits/category_creation_screen.dart';
+import 'features/habits/streak_goal_screen.dart';
+import 'features/habits/reminder_screen.dart';
+import 'core/data/models/habit.dart';
 
 /// Root app widget
 class App extends StatelessWidget {
@@ -20,6 +25,22 @@ class App extends StatelessWidget {
         GoRoute(
           path: '/home',
           builder: (context, state) => const HomeScreen(),
+        ),
+        GoRoute(
+          path: '/add_habit',
+          builder: (context, state) => AddEditHabitScreen(habit: state.extra as Habit?),
+        ),
+        GoRoute(
+          path: '/create_category',
+          builder: (context, state) => const CategoryCreationScreen(),
+        ),
+        GoRoute(
+          path: '/streak_goal',
+          builder: (context, state) => StreakGoalScreen(current: state.extra as StreakGoal?),
+        ),
+        GoRoute(
+          path: '/reminder',
+          builder: (context, state) => ReminderScreen(current: state.extra as List<int>?),
         ),
       ],
     );

--- a/lib/core/data/habit_repository.dart
+++ b/lib/core/data/habit_repository.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'models/habit.dart';
+
+/// Simple repository persisting habits using [SharedPreferences].
+class HabitRepository {
+  static const _habitsKey = 'habits';
+
+  /// Loads all saved habits.
+  static Future<List<Habit>> loadHabits() async {
+    final prefs = await SharedPreferences.getInstance();
+    final jsonString = prefs.getString(_habitsKey);
+    if (jsonString == null) return [];
+    final List list = jsonDecode(jsonString) as List;
+    return list.map((e) => Habit.fromMap(e as Map<String, dynamic>)).toList();
+  }
+
+  /// Persists a list of habits.
+  static Future<void> _saveHabits(List<Habit> habits) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(habits.map((e) => e.toMap()).toList());
+    await prefs.setString(_habitsKey, data);
+  }
+
+  /// Adds a new habit.
+  static Future<void> addHabit(Habit habit) async {
+    final habits = await loadHabits();
+    habits.add(habit);
+    await _saveHabits(habits);
+  }
+
+  /// Updates an existing habit.
+  static Future<void> updateHabit(Habit habit) async {
+    final habits = await loadHabits();
+    final index = habits.indexWhere((h) => h.id == habit.id);
+    if (index >= 0) {
+      habits[index] = habit;
+      await _saveHabits(habits);
+    }
+  }
+}

--- a/lib/core/data/models/habit.dart
+++ b/lib/core/data/models/habit.dart
@@ -1,0 +1,89 @@
+import 'dart:convert';
+
+/// Enum describing possible streak goal intervals.
+enum StreakGoal { none, daily, weekly, monthly }
+
+/// Enum describing completion tracking behavior.
+enum CompletionTrackingType { stepByStep, customValue }
+
+/// Model class representing a habit.
+class Habit {
+  Habit({
+    required this.id,
+    required this.name,
+    this.description = '',
+    this.color = 0xFF2196F3,
+    this.iconData = 0xe3af, // default Icons.check
+    this.streakGoal = StreakGoal.none,
+    this.reminderDays = const [],
+    this.categories = const [],
+    this.completionTrackingType = CompletionTrackingType.stepByStep,
+    this.completionTarget = 1,
+  });
+
+  /// Unique identifier for the habit.
+  final String id;
+
+  /// Name displayed to the user.
+  String name;
+
+  /// Optional description text.
+  String description;
+
+  /// ARGB color value for the habit.
+  int color;
+
+  /// CodePoint for the [IconData] used to display the habit.
+  int iconData;
+
+  /// Streak goal interval.
+  StreakGoal streakGoal;
+
+  /// Days of week to show reminders. 1 = Monday ... 7 = Sunday.
+  List<int> reminderDays;
+
+  /// Names of categories assigned to this habit.
+  List<String> categories;
+
+  /// How completion is tracked.
+  CompletionTrackingType completionTrackingType;
+
+  /// Target value per day when using [CompletionTrackingType.customValue].
+  int completionTarget;
+
+  /// Serializes this habit to a map.
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'name': name,
+        'description': description,
+        'color': color,
+        'iconData': iconData,
+        'streakGoal': streakGoal.index,
+        'reminderDays': reminderDays,
+        'categories': categories,
+        'completionTrackingType': completionTrackingType.index,
+        'completionTarget': completionTarget,
+      };
+
+  /// Converts this habit to JSON.
+  String toJson() => jsonEncode(toMap());
+
+  /// Creates a habit from a map.
+  factory Habit.fromMap(Map<String, dynamic> map) => Habit(
+        id: map['id'] as String,
+        name: map['name'] as String,
+        description: map['description'] as String? ?? '',
+        color: map['color'] as int? ?? 0xFF2196F3,
+        iconData: map['iconData'] as int? ?? 0xe3af,
+        streakGoal: StreakGoal.values[map['streakGoal'] as int? ?? 0],
+        reminderDays: List<int>.from(map['reminderDays'] as List? ?? []),
+        categories: List<String>.from(map['categories'] as List? ?? []),
+        completionTrackingType: CompletionTrackingType
+            .values[map['completionTrackingType'] as int? ?? 0],
+        completionTarget: map['completionTarget'] as int? ?? 1,
+      );
+
+  /// Creates a habit from JSON string.
+  factory Habit.fromJson(String json) =>
+      Habit.fromMap(jsonDecode(json) as Map<String, dynamic>);
+}

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -1,0 +1,480 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../core/data/habit_repository.dart';
+import '../../core/data/models/habit.dart';
+import 'category_creation_screen.dart';
+import 'reminder_screen.dart';
+import 'streak_goal_screen.dart';
+
+/// Screen for creating or editing a habit.
+class AddEditHabitScreen extends StatefulWidget {
+  const AddEditHabitScreen({super.key, this.habit});
+
+  /// Habit being edited. When null, a new habit is created.
+  final Habit? habit;
+
+  @override
+  State<AddEditHabitScreen> createState() => _AddEditHabitScreenState();
+}
+
+class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
+  late final TextEditingController _nameController;
+  late final TextEditingController _descriptionController;
+
+  IconData _icon = Icons.check;
+  int _color = Colors.blue.value;
+
+  bool _advancedExpanded = false;
+
+  StreakGoal _streakGoal = StreakGoal.none;
+  List<int> _reminderDays = [];
+  List<String> _categories = [];
+  CompletionTrackingType _trackingType = CompletionTrackingType.stepByStep;
+  int _completionTarget = 1;
+
+  bool get _isEditing => widget.habit != null;
+
+  @override
+  void initState() {
+    super.initState();
+    final habit = widget.habit;
+    _nameController = TextEditingController(text: habit?.name ?? '');
+    _descriptionController =
+        TextEditingController(text: habit?.description ?? '');
+    if (habit != null) {
+      _icon = IconData(habit.iconData, fontFamily: 'MaterialIcons');
+      _color = habit.color;
+      _streakGoal = habit.streakGoal;
+      _reminderDays = List.of(habit.reminderDays);
+      _categories = List.of(habit.categories);
+      _trackingType = habit.completionTrackingType;
+      _completionTarget = habit.completionTarget;
+    }
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  /// Opens a bottom sheet allowing the user to pick an icon.
+  Future<void> _pickIcon() async {
+    final result = await showModalBottomSheet<IconData>(
+      context: context,
+      builder: (context) => _IconPicker(initial: _icon),
+    );
+    if (result != null) {
+      setState(() => _icon = result);
+    }
+  }
+
+  /// Allows the user to pick a color.
+  Future<void> _pickColor() async {
+    final result = await showModalBottomSheet<int>(
+      context: context,
+      builder: (context) => _ColorPicker(initial: _color),
+    );
+    if (result != null) {
+      setState(() => _color = result);
+    }
+  }
+
+  /// Navigates to the streak goal screen.
+  Future<void> _editStreakGoal() async {
+    final result = await context.push<StreakGoal>(
+      '/streak_goal',
+      extra: _streakGoal,
+    );
+    if (result != null) {
+      setState(() => _streakGoal = result);
+    }
+  }
+
+  /// Navigates to the reminder screen.
+  Future<void> _editReminders() async {
+    final result = await context.push<List<int>>(
+      '/reminder',
+      extra: _reminderDays,
+    );
+    if (result != null) {
+      setState(() => _reminderDays = result);
+    }
+  }
+
+  /// Navigates to the category creation screen and adds a new category.
+  Future<void> _createCategory() async {
+    final result = await context.push<String>('/create_category');
+    if (result != null) {
+      setState(() => _categories.add(result));
+    }
+  }
+
+  /// Saves the habit and pops the screen.
+  Future<void> _save() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    final habit = Habit(
+      id: widget.habit?.id ?? const Uuid().v4(),
+      name: name,
+      description: _descriptionController.text.trim(),
+      color: _color,
+      iconData: _icon.codePoint,
+      streakGoal: _streakGoal,
+      reminderDays: _reminderDays,
+      categories: _categories,
+      completionTrackingType: _trackingType,
+      completionTarget: _completionTarget,
+    );
+    if (_isEditing) {
+      await HabitRepository.updateHabit(habit);
+    } else {
+      await HabitRepository.addHabit(habit);
+    }
+    if (mounted) context.pop();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isValid = _nameController.text.trim().isNotEmpty;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Edit Habit' : 'New Habit'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Habit Name'),
+              onChanged: (_) => setState(() {}),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(labelText: 'Description'),
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              leading: Icon(_icon, color: Color(_color)),
+              title: const Text('Icon'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: _pickIcon,
+            ),
+            ListTile(
+              leading: Container(
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                  color: Color(_color),
+                  shape: BoxShape.circle,
+                ),
+              ),
+              title: const Text('Color'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: _pickColor,
+            ),
+            const SizedBox(height: 8),
+            GestureDetector(
+              onTap: () => setState(() => _advancedExpanded = !_advancedExpanded),
+              child: Row(
+                children: [
+                  const Text('Advanced Options'),
+                  const Spacer(),
+                  Icon(_advancedExpanded
+                      ? Icons.expand_less
+                      : Icons.expand_more),
+                ],
+              ),
+            ),
+            AnimatedCrossFade(
+              firstChild: const SizedBox.shrink(),
+              secondChild: Column(
+                children: [
+                  ListTile(
+                    title: const Text('Streak Goal'),
+                    subtitle: Text(_streakGoal.name),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: _editStreakGoal,
+                  ),
+                  ListTile(
+                    title: const Text('Reminder Days'),
+                    subtitle: Text(
+                      _reminderDays.isEmpty
+                          ? 'None'
+                          : _reminderDays.map(_weekdayName).join(', '),
+                    ),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: _editReminders,
+                  ),
+                  ListTile(
+                    title: const Text('Categories'),
+                    subtitle: Text(
+                      _categories.isEmpty
+                          ? 'None'
+                          : _categories.join(', '),
+                    ),
+                    trailing: const Icon(Icons.chevron_right),
+                    onTap: _createCategory,
+                  ),
+                  SwitchListTile(
+                    title: const Text('Step By Step'),
+                    value: _trackingType ==
+                        CompletionTrackingType.stepByStep,
+                    onChanged: (val) => setState(() {
+                      _trackingType = val
+                          ? CompletionTrackingType.stepByStep
+                          : CompletionTrackingType.customValue;
+                    }),
+                  ),
+                  if (_trackingType ==
+                      CompletionTrackingType.customValue)
+                    Row(
+                      children: [
+                        IconButton(
+                          icon: const Icon(Icons.remove_circle_outline),
+                          onPressed: _completionTarget > 1
+                              ? () => setState(() => _completionTarget--)
+                              : null,
+                        ),
+                        Expanded(
+                          child: TextFormField(
+                            textAlign: TextAlign.center,
+                            keyboardType: TextInputType.number,
+                            initialValue: '$_completionTarget',
+                            onChanged: (v) {
+                              final val = int.tryParse(v) ?? 1;
+                              setState(() => _completionTarget = val);
+                            },
+                          ),
+                        ),
+                        IconButton(
+                          icon: const Icon(Icons.add_circle_outline),
+                          onPressed: () =>
+                              setState(() => _completionTarget++),
+                        ),
+                      ],
+                    ),
+                ],
+              ),
+              crossFadeState: _advancedExpanded
+                  ? CrossFadeState.showSecond
+                  : CrossFadeState.showFirst,
+              duration: const Duration(milliseconds: 300),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ElevatedButton(
+          onPressed: isValid ? _save : null,
+          child: const Text('Save'),
+        ),
+      ),
+    );
+  }
+
+  /// Returns weekday name for given int (1=Mon).
+  String _weekdayName(int day) {
+    const names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    return names[day - 1];
+  }
+}
+
+/// Simple icon picker with a searchable grid.
+class _IconPicker extends StatefulWidget {
+  const _IconPicker({required this.initial});
+  final IconData initial;
+
+  @override
+  State<_IconPicker> createState() => _IconPickerState();
+}
+
+class _IconPickerState extends State<_IconPicker> {
+  final TextEditingController _searchController = TextEditingController();
+  late List<IconData> _icons;
+  late IconData _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initial;
+    _icons = _allIcons;
+    _searchController.addListener(_filter);
+  }
+
+  void _filter() {
+    final query = _searchController.text.toLowerCase();
+    setState(() {
+      _icons = _allIcons
+          .where((e) => e.codePoint
+              .toString()
+              .contains(query))
+          .toList();
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                hintText: 'Search icons',
+                prefixIcon: Icon(Icons.search),
+              ),
+            ),
+          ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 6,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+              ),
+              itemCount: _icons.length,
+              itemBuilder: (context, index) {
+                final icon = _icons[index];
+                final selected = icon == _selected;
+                return GestureDetector(
+                  onTap: () => setState(() => _selected = icon),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: selected
+                          ? Theme.of(context).colorScheme.primary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Icon(icon,
+                        color: selected ? Colors.white : Colors.white70),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context, _selected),
+              child: const Text('Select'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Simple color picker bottom sheet.
+class _ColorPicker extends StatefulWidget {
+  const _ColorPicker({required this.initial});
+  final int initial;
+  @override
+  State<_ColorPicker> createState() => _ColorPickerState();
+}
+
+class _ColorPickerState extends State<_ColorPicker> {
+  static const colors = [
+    Colors.red,
+    Colors.pink,
+    Colors.purple,
+    Colors.deepPurple,
+    Colors.blue,
+    Colors.lightBlue,
+    Colors.cyan,
+    Colors.teal,
+    Colors.green,
+    Colors.lime,
+    Colors.orange,
+    Colors.brown,
+  ];
+  late int _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.initial;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(16),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 5,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+              ),
+              itemCount: colors.length,
+              itemBuilder: (context, index) {
+                final color = colors[index];
+                final selected = color.value == _selected;
+                return GestureDetector(
+                  onTap: () => setState(() => _selected = color.value),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: color,
+                      shape: BoxShape.circle,
+                      border: selected
+                          ? Border.all(
+                              color: Colors.white,
+                              width: 3,
+                            )
+                          : null,
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, _selected),
+            child: const Text('Select'),
+          ),
+          const SizedBox(height: 8),
+        ],
+      ),
+    );
+  }
+}
+
+/// Limited set of icons displayed in the picker.
+const List<IconData> _allIcons = [
+  Icons.star_border,
+  Icons.favorite_border,
+  Icons.run_circle_outlined,
+  Icons.book_outlined,
+  Icons.fitness_center,
+  Icons.savings_outlined,
+  Icons.school_outlined,
+  Icons.self_improvement,
+  Icons.work_outline,
+  Icons.music_note,
+  Icons.food_bank_outlined,
+  Icons.water_drop_outlined,
+  Icons.timer_outlined,
+  Icons.mood_outlined,
+  Icons.code,
+];

--- a/lib/features/habits/category_creation_screen.dart
+++ b/lib/features/habits/category_creation_screen.dart
@@ -1,0 +1,173 @@
+import 'package:flutter/material.dart';
+
+/// Screen allowing the user to create a new category by selecting an icon and
+/// entering a name.
+class CategoryCreationScreen extends StatefulWidget {
+  const CategoryCreationScreen({super.key});
+
+  @override
+  State<CategoryCreationScreen> createState() => _CategoryCreationScreenState();
+}
+
+class _CategoryCreationScreenState extends State<CategoryCreationScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  IconData _icon = Icons.category;
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pickIcon() async {
+    final icon = await showModalBottomSheet<IconData>(
+      context: context,
+      builder: (context) => const _IconPicker(),
+    );
+    if (icon != null) setState(() => _icon = icon);
+  }
+
+  void _save() {
+    final name = _nameController.text.trim();
+    if (name.isEmpty) return;
+    Navigator.pop(context, name);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isValid = _nameController.text.trim().isNotEmpty;
+    return Scaffold(
+      appBar: AppBar(title: const Text('New Category')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            ListTile(
+              leading: Icon(_icon),
+              title: const Text('Icon'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: _pickIcon,
+            ),
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+              onChanged: (_) => setState(() {}),
+            ),
+            const Spacer(),
+            ElevatedButton(
+              onPressed: isValid ? _save : null,
+              child: const Text('Create'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _IconPicker extends StatefulWidget {
+  const _IconPicker();
+  @override
+  State<_IconPicker> createState() => _IconPickerState();
+}
+
+class _IconPickerState extends State<_IconPicker> {
+  final TextEditingController _searchController = TextEditingController();
+  late List<IconData> _icons;
+  IconData? _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _icons = _allIcons;
+    _searchController.addListener(_filter);
+  }
+
+  void _filter() {
+    final query = _searchController.text.toLowerCase();
+    setState(() {
+      _icons = _allIcons
+          .where((e) => e.codePoint.toString().contains(query))
+          .toList();
+    });
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: TextField(
+              controller: _searchController,
+              decoration: const InputDecoration(
+                hintText: 'Search icons',
+                prefixIcon: Icon(Icons.search),
+              ),
+            ),
+          ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 6,
+                crossAxisSpacing: 8,
+                mainAxisSpacing: 8,
+              ),
+              itemCount: _icons.length,
+              itemBuilder: (context, index) {
+                final icon = _icons[index];
+                final selected = icon == _selected;
+                return GestureDetector(
+                  onTap: () => setState(() => _selected = icon),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: selected
+                          ? Theme.of(context).colorScheme.primary
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    child: Icon(icon,
+                        color: selected ? Colors.white : Colors.white70),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context, _selected),
+              child: const Text('Select'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+const List<IconData> _allIcons = [
+  Icons.star_border,
+  Icons.favorite_border,
+  Icons.run_circle_outlined,
+  Icons.book_outlined,
+  Icons.fitness_center,
+  Icons.savings_outlined,
+  Icons.school_outlined,
+  Icons.self_improvement,
+  Icons.work_outline,
+  Icons.music_note,
+  Icons.food_bank_outlined,
+  Icons.water_drop_outlined,
+  Icons.timer_outlined,
+  Icons.mood_outlined,
+  Icons.code,
+];

--- a/lib/features/habits/reminder_screen.dart
+++ b/lib/features/habits/reminder_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+
+/// Screen allowing the user to select reminder days of the week.
+class ReminderScreen extends StatefulWidget {
+  const ReminderScreen({super.key, this.current});
+  final List<int>? current;
+
+  @override
+  State<ReminderScreen> createState() => _ReminderScreenState();
+}
+
+class _ReminderScreenState extends State<ReminderScreen> {
+  late List<int> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = List<int>.from(widget.current ?? []);
+  }
+
+  void _toggle(int day) {
+    setState(() {
+      if (_selected.contains(day)) {
+        _selected.remove(day);
+      } else {
+        _selected.add(day);
+      }
+    });
+  }
+
+  void _toggleAll() {
+    setState(() {
+      if (_selected.length == 7) {
+        _selected.clear();
+      } else {
+        _selected = [1, 2, 3, 4, 5, 6, 7];
+      }
+    });
+  }
+
+  void _save() {
+    Navigator.pop(context, _selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reminders')),
+      body: Column(
+        children: [
+          ListTile(
+            title: const Text('Select all'),
+            trailing: Checkbox(
+              value: _selected.length == 7,
+              onChanged: (_) => _toggleAll(),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: 7,
+              itemBuilder: (context, index) {
+                final day = index + 1;
+                return CheckboxListTile(
+                  title: Text(_weekdayName(day)),
+                  value: _selected.contains(day),
+                  onChanged: (_) => _toggle(day),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _save,
+        child: const Icon(Icons.check),
+      ),
+    );
+  }
+
+  String _weekdayName(int day) {
+    const names = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+    return names[day - 1];
+  }
+}

--- a/lib/features/habits/streak_goal_screen.dart
+++ b/lib/features/habits/streak_goal_screen.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import '../../core/data/models/habit.dart';
+
+/// Screen to select a streak goal interval.
+class StreakGoalScreen extends StatefulWidget {
+  const StreakGoalScreen({super.key, this.current});
+  final StreakGoal? current;
+
+  @override
+  State<StreakGoalScreen> createState() => _StreakGoalScreenState();
+}
+
+class _StreakGoalScreenState extends State<StreakGoalScreen> {
+  late StreakGoal _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = widget.current ?? StreakGoal.none;
+  }
+
+  void _save() {
+    Navigator.pop(context, _selected);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Streak Goal')),
+      body: Column(
+        children: StreakGoal.values
+            .map(
+              (e) => RadioListTile<StreakGoal>(
+                title: Text(e.name),
+                value: e,
+                groupValue: _selected,
+                onChanged: (val) => setState(() => _selected = val!),
+              ),
+            )
+            .toList(),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _save,
+        child: const Icon(Icons.check),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,15 +1,41 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../core/data/habit_repository.dart';
+import '../../core/data/models/habit.dart';
+
 /// Home screen shown when the user has completed onboarding.
 ///
 /// Displays an empty state prompting the user to add their first habit.
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
-  /// Navigates to the add habit flow.
-  void _goToAddHabit(BuildContext context) {
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  late Future<List<Habit>> _habitsFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _habitsFuture = HabitRepository.loadHabits();
+  }
+
+  Future<void> _refresh() async {
+    final habits = await HabitRepository.loadHabits();
+    setState(() {
+      _habitsFuture = Future.value(habits);
+    });
+  }
+
+  void _goToAddHabit() {
     context.go('/add_habit');
+  }
+
+  void _editHabit(Habit habit) {
+    context.go('/add_habit', extra: habit);
   }
 
   @override
@@ -44,58 +70,86 @@ class HomeScreen extends StatelessWidget {
           ),
           IconButton(
             icon: const Icon(Icons.add_circle_outline, color: Colors.white),
-            onPressed: () => _goToAddHabit(context),
+            onPressed: _goToAddHabit,
           ),
         ],
       ),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 80,
-                height: 80,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: Colors.white.withOpacity(0.1),
-                ),
-                child: const Icon(Icons.add, color: Colors.white, size: 40),
-              ),
-              const SizedBox(height: 24),
-              const Text(
-                'No habit found',
-                style: TextStyle(
-                  color: Colors.white,
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              const SizedBox(height: 8),
-              const Text(
-                'Create a new habit to track your progress',
-                textAlign: TextAlign.center,
-                style: TextStyle(color: Colors.white70),
-              ),
-              const SizedBox(height: 32),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton(
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: purple,
-                    foregroundColor: Colors.white,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
+      body: FutureBuilder<List<Habit>>(
+        future: _habitsFuture,
+        builder: (context, snapshot) {
+          final habits = snapshot.data ?? [];
+          if (habits.isEmpty) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 80,
+                      height: 80,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Colors.white.withOpacity(0.1),
+                      ),
+                      child: const Icon(Icons.add, color: Colors.white, size: 40),
                     ),
-                  ),
-                  onPressed: () => _goToAddHabit(context),
-                  child: const Text('Get started'),
+                    const SizedBox(height: 24),
+                    const Text(
+                      'No habit found',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 24,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    const Text(
+                      'Create a new habit to track your progress',
+                      textAlign: TextAlign.center,
+                      style: TextStyle(color: Colors.white70),
+                    ),
+                    const SizedBox(height: 32),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: purple,
+                          foregroundColor: Colors.white,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(30),
+                          ),
+                        ),
+                        onPressed: _goToAddHabit,
+                        child: const Text('Get started'),
+                      ),
+                    ),
+                  ],
                 ),
               ),
-            ],
-          ),
-        ),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.builder(
+              itemCount: habits.length,
+              itemBuilder: (context, index) {
+                final habit = habits[index];
+                return ListTile(
+                  leading: Icon(
+                    IconData(habit.iconData, fontFamily: 'MaterialIcons'),
+                    color: Color(habit.color),
+                  ),
+                  title: Text(habit.name, style: const TextStyle(color: Colors.white)),
+                  subtitle: Text(habit.description,
+                      style: const TextStyle(color: Colors.white70)),
+                  onTap: () => _editHabit(habit),
+                );
+              },
+            ),
+          );
+        },
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.2.2
   go_router: ^13.2.0
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement `Habit` model and repository for saving to SharedPreferences
- add screens for adding, editing, and configuring habits
- show saved habits on the home screen
- register new routes and dependencies

## Testing
- `dart format lib` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687621045d708329a177069a271b820d