### PR TITLE
Revamp habit management screens

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -44,11 +44,31 @@ class App extends StatelessWidget {
         ),
       ],
     );
+    final baseDark = ThemeData.dark();
     return MaterialApp.router(
       title: 'Habit Tracker',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      darkTheme: ThemeData.dark(),
-      themeMode: ThemeMode.system,
+      themeMode: ThemeMode.dark,
+      theme: ThemeData.dark().copyWith(
+        colorScheme: baseDark.colorScheme.copyWith(
+          primary: const Color(0xFF8A2BE2),
+          secondary: const Color(0xFF8A2BE2),
+        ),
+        scaffoldBackgroundColor: const Color(0xFF121212),
+        appBarTheme: const AppBarTheme(
+          backgroundColor: Color(0xFF121212),
+          elevation: 0,
+          iconTheme: IconThemeData(color: Colors.white),
+        ),
+        inputDecorationTheme: const InputDecorationTheme(
+          filled: true,
+          fillColor: Color(0xFF1E1E1E),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.all(Radius.circular(12)),
+            borderSide: BorderSide.none,
+          ),
+          hintStyle: TextStyle(color: Colors.white70),
+        ),
+      ),
       routerConfig: router,
     );
   }

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -34,6 +34,21 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
   CompletionTrackingType _trackingType = CompletionTrackingType.stepByStep;
   int _completionTarget = 1;
 
+  static const List<String> _allCategories = [
+    'Art',
+    'Finance',
+    'Fitness',
+    'Health',
+    'Nutrition',
+    'Social',
+    'Study',
+    'Work',
+    'Other',
+    'Morning',
+    'Day',
+    'Evening',
+  ];
+
   bool get _isEditing => widget.habit != null;
 
   @override
@@ -61,26 +76,22 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
     super.dispose();
   }
 
-  /// Opens a bottom sheet allowing the user to pick an icon.
+  /// Opens a fullscreen dialog allowing the user to pick an icon.
   Future<void> _pickIcon() async {
-    final result = await showModalBottomSheet<IconData>(
+    final result = await showDialog<IconData>(
       context: context,
       builder: (context) => _IconPicker(initial: _icon),
     );
-    if (result != null) {
-      setState(() => _icon = result);
-    }
+    if (result != null) setState(() => _icon = result);
   }
 
-  /// Allows the user to pick a color.
+  /// Allows the user to pick a color using a modal dialog.
   Future<void> _pickColor() async {
-    final result = await showModalBottomSheet<int>(
+    final result = await showDialog<int>(
       context: context,
       builder: (context) => _ColorPicker(initial: _color),
     );
-    if (result != null) {
-      setState(() => _color = result);
-    }
+    if (result != null) setState(() => _color = result);
   }
 
   /// Navigates to the streak goal screen.
@@ -113,6 +124,16 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
     }
   }
 
+  void _toggleCategory(String name) {
+    setState(() {
+      if (_categories.contains(name)) {
+        _categories.remove(name);
+      } else {
+        _categories.add(name);
+      }
+    });
+  }
+
   /// Saves the habit and pops the screen.
   Future<void> _save() async {
     final name = _nameController.text.trim();
@@ -139,145 +160,223 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final isValid = _nameController.text.trim().isNotEmpty;
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(_isEditing ? 'Edit Habit' : 'New Habit'),
-      ),
-      body: SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            TextField(
-              controller: _nameController,
-              decoration: const InputDecoration(labelText: 'Habit Name'),
-              onChanged: (_) => setState(() {}),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: _descriptionController,
-              decoration: const InputDecoration(labelText: 'Description'),
-            ),
-            const SizedBox(height: 16),
-            ListTile(
-              leading: Icon(_icon, color: Color(_color)),
-              title: const Text('Icon'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: _pickIcon,
-            ),
-            ListTile(
-              leading: Container(
-                width: 24,
-                height: 24,
-                decoration: BoxDecoration(
-                  color: Color(_color),
-                  shape: BoxShape.circle,
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            icon: const Icon(Icons.close, size: 24),
+            onPressed: () => context.pop(),
+          ),
+          title: Text(
+            _isEditing ? 'Edit Habit' : 'New Habit',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          centerTitle: true,
+          backgroundColor: Colors.transparent,
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _nameController,
+                style: const TextStyle(
+                    color: Colors.white, fontWeight: FontWeight.bold),
+                decoration: const InputDecoration(
+                  hintText: 'Name',
+                ),
+                onChanged: (_) => setState(() {}),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _descriptionController,
+                style: const TextStyle(color: Colors.white70),
+                decoration: const InputDecoration(hintText: 'Description'),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  GestureDetector(
+                    onTap: _pickIcon,
+                    child: Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF1A1A1A),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: const Color(0xFF2A2A2A)),
+                      ),
+                      child: Icon(_icon, color: Color(_color)),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  GestureDetector(
+                    onTap: _pickColor,
+                    child: Container(
+                      width: 48,
+                      height: 48,
+                      decoration: BoxDecoration(
+                        color: Color(_color),
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: const Color(0xFF2A2A2A)),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              const Divider(color: Color(0xFF2A2A2A)),
+              const SizedBox(height: 8),
+              GestureDetector(
+                onTap: () =>
+                    setState(() => _advancedExpanded = !_advancedExpanded),
+                child: Row(
+                  children: [
+                    const Text('Advanced Options',
+                        style: TextStyle(color: Color(0xFFB0B0B0))),
+                    const Spacer(),
+                    Icon(
+                      _advancedExpanded
+                          ? Icons.keyboard_arrow_up
+                          : Icons.keyboard_arrow_down,
+                      color: Colors.white,
+                    ),
+                  ],
                 ),
               ),
-              title: const Text('Color'),
-              trailing: const Icon(Icons.chevron_right),
-              onTap: _pickColor,
-            ),
-            const SizedBox(height: 8),
-            GestureDetector(
-              onTap: () => setState(() => _advancedExpanded = !_advancedExpanded),
-              child: Row(
-                children: [
-                  const Text('Advanced Options'),
-                  const Spacer(),
-                  Icon(_advancedExpanded
-                      ? Icons.expand_less
-                      : Icons.expand_more),
-                ],
+              AnimatedCrossFade(
+                firstChild: const SizedBox.shrink(),
+                secondChild: _buildAdvancedOptions(),
+                crossFadeState: _advancedExpanded
+                    ? CrossFadeState.showSecond
+                    : CrossFadeState.showFirst,
+                duration: const Duration(milliseconds: 300),
               ),
-            ),
-            AnimatedCrossFade(
-              firstChild: const SizedBox.shrink(),
-              secondChild: Column(
-                children: [
-                  ListTile(
-                    title: const Text('Streak Goal'),
-                    subtitle: Text(_streakGoal.name),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: _editStreakGoal,
-                  ),
-                  ListTile(
-                    title: const Text('Reminder Days'),
-                    subtitle: Text(
-                      _reminderDays.isEmpty
-                          ? 'None'
-                          : _reminderDays.map(_weekdayName).join(', '),
-                    ),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: _editReminders,
-                  ),
-                  ListTile(
-                    title: const Text('Categories'),
-                    subtitle: Text(
-                      _categories.isEmpty
-                          ? 'None'
-                          : _categories.join(', '),
-                    ),
-                    trailing: const Icon(Icons.chevron_right),
-                    onTap: _createCategory,
-                  ),
-                  SwitchListTile(
-                    title: const Text('Step By Step'),
-                    value: _trackingType ==
-                        CompletionTrackingType.stepByStep,
-                    onChanged: (val) => setState(() {
-                      _trackingType = val
-                          ? CompletionTrackingType.stepByStep
-                          : CompletionTrackingType.customValue;
-                    }),
-                  ),
-                  if (_trackingType ==
-                      CompletionTrackingType.customValue)
-                    Row(
-                      children: [
-                        IconButton(
-                          icon: const Icon(Icons.remove_circle_outline),
-                          onPressed: _completionTarget > 1
-                              ? () => setState(() => _completionTarget--)
-                              : null,
-                        ),
-                        Expanded(
-                          child: TextFormField(
-                            textAlign: TextAlign.center,
-                            keyboardType: TextInputType.number,
-                            initialValue: '$_completionTarget',
-                            onChanged: (v) {
-                              final val = int.tryParse(v) ?? 1;
-                              setState(() => _completionTarget = val);
-                            },
-                          ),
-                        ),
-                        IconButton(
-                          icon: const Icon(Icons.add_circle_outline),
-                          onPressed: () =>
-                              setState(() => _completionTarget++),
-                        ),
-                      ],
-                    ),
-                ],
+              const SizedBox(height: 80),
+            ],
+          ),
+        ),
+        bottomNavigationBar: Padding(
+          padding: const EdgeInsets.all(16),
+          child: SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor:
+                    isValid ? const Color(0xFF8A2BE2) : Colors.white24,
+                foregroundColor: Colors.white,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
               ),
-              crossFadeState: _advancedExpanded
-                  ? CrossFadeState.showSecond
-                  : CrossFadeState.showFirst,
-              duration: const Duration(milliseconds: 300),
+              onPressed: isValid ? _save : null,
+              child: const Text('Save'),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdvancedOptions() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ListTile(
+          title: const Text('Streak Goal'),
+          subtitle: Text(_streakGoal.name),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: _editStreakGoal,
+        ),
+        ListTile(
+          title: const Text('Reminder'),
+          subtitle: Text(
+            _reminderDays.isEmpty
+                ? 'None'
+                : _reminderDays.map(_weekdayName).join(', '),
+          ),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: _editReminders,
+        ),
+        Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: [
+            ..._allCategories.map((c) => FilterChip(
+                  label: Text(c),
+                  selected: _categories.contains(c),
+                  onSelected: (_) => _toggleCategory(c),
+                )),
+            ActionChip(
+              label: const Text('+ Create your own'),
+              onPressed: _createCategory,
             ),
           ],
         ),
-      ),
-      bottomNavigationBar: Padding(
-        padding: const EdgeInsets.all(16),
-        child: ElevatedButton(
-          onPressed: isValid ? _save : null,
-          child: const Text('Save'),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: ChoiceChip(
+                label: const Text('Step By Step'),
+                selected: _trackingType ==
+                    CompletionTrackingType.stepByStep,
+                onSelected: (_) => setState(
+                    () => _trackingType = CompletionTrackingType.stepByStep),
+              ),
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: ChoiceChip(
+                label: const Text('Custom Value'),
+                selected:
+                    _trackingType == CompletionTrackingType.customValue,
+                onSelected: (_) => setState(
+                    () => _trackingType = CompletionTrackingType.customValue),
+              ),
+            ),
+          ],
         ),
-      ),
+        if (_trackingType == CompletionTrackingType.customValue) ...[
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              IconButton(
+                icon: const Icon(Icons.remove),
+                onPressed: _completionTarget > 1
+                    ? () => setState(() => _completionTarget--)
+                    : null,
+              ),
+              Expanded(
+                child: Text(
+                  '$_completionTarget',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              IconButton(
+                icon: const Icon(Icons.add),
+                onPressed: () =>
+                    setState(() => _completionTarget++),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          const Text(
+            'The square will be filled completely when this number is met',
+            style: TextStyle(color: Color(0xFFB0B0B0), fontSize: 12),
+          ),
+        ] else
+          const Padding(
+            padding: EdgeInsets.only(top: 8),
+            child: Text(
+              'Increment by 1 with each completion.',
+              style: TextStyle(color: Color(0xFFB0B0B0), fontSize: 12),
+            ),
+          ),
+      ],
     );
   }
 
@@ -329,26 +428,34 @@ class _IconPickerState extends State<_IconPicker> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Column(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick Icon'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+      ),
+      body: Column(
         children: [
           Padding(
             padding: const EdgeInsets.all(8),
             child: TextField(
               controller: _searchController,
               decoration: const InputDecoration(
-                hintText: 'Search icons',
+                hintText: 'Type a search term',
                 prefixIcon: Icon(Icons.search),
               ),
             ),
           ),
           Expanded(
             child: GridView.builder(
-              padding: const EdgeInsets.all(8),
+              padding: const EdgeInsets.all(12),
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 6,
-                crossAxisSpacing: 8,
-                mainAxisSpacing: 8,
+                crossAxisCount: 7,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
               ),
               itemCount: _icons.length,
               itemBuilder: (context, index) {
@@ -356,22 +463,26 @@ class _IconPickerState extends State<_IconPicker> {
                 final selected = icon == _selected;
                 return GestureDetector(
                   onTap: () => setState(() => _selected = icon),
-                  child: Container(
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
                     decoration: BoxDecoration(
-                      color: selected
-                          ? Theme.of(context).colorScheme.primary
-                          : Colors.transparent,
-                      borderRadius: BorderRadius.circular(8),
+                      color: const Color(0xFF1A1A1A),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: selected
+                            ? const Color(0xFF8A2BE2)
+                            : Colors.transparent,
+                        width: 2,
+                      ),
                     ),
-                    child: Icon(icon,
-                        color: selected ? Colors.white : Colors.white70),
+                    child: Icon(icon, color: Colors.white),
                   ),
                 );
               },
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.all(16),
             child: ElevatedButton(
               onPressed: () => Navigator.pop(context, _selected),
               child: const Text('Select'),
@@ -393,18 +504,35 @@ class _ColorPicker extends StatefulWidget {
 
 class _ColorPickerState extends State<_ColorPicker> {
   static const colors = [
-    Colors.red,
     Colors.pink,
-    Colors.purple,
-    Colors.deepPurple,
-    Colors.blue,
-    Colors.lightBlue,
-    Colors.cyan,
-    Colors.teal,
-    Colors.green,
-    Colors.lime,
+    Colors.red,
+    Colors.deepOrange,
     Colors.orange,
+    Colors.amber,
+    Colors.yellow,
+    Colors.lightGreen,
+    Colors.green,
+    Colors.teal,
+    Colors.cyan,
+    Colors.lightBlue,
+    Colors.blue,
+    Colors.indigo,
+    Colors.deepPurple,
+    Colors.purple,
     Colors.brown,
+    Colors.grey,
+    Colors.blueGrey,
+    Color(0xFFB39DDB),
+    Color(0xFF80CBC4),
+    Color(0xFFFFAB91),
+    Color(0xFFE6EE9C),
+    Color(0xFFCE93D8),
+    Color(0xFFA5D6A7),
+    Color(0xFFFFF59D),
+    Color(0xFFB0BEC5),
+    Color(0xFF90A4AE),
+    Color(0xFFE0E0E0),
+    Color(0xFF4DB6AC),
   ];
   late int _selected;
 
@@ -416,16 +544,24 @@ class _ColorPickerState extends State<_ColorPicker> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Column(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick Color'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+      ),
+      body: Column(
         children: [
           Expanded(
             child: GridView.builder(
-              padding: const EdgeInsets.all(16),
+              padding: const EdgeInsets.all(12),
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 5,
-                crossAxisSpacing: 8,
-                mainAxisSpacing: 8,
+                crossAxisCount: 6,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
               ),
               itemCount: colors.length,
               itemBuilder: (context, index) {
@@ -433,27 +569,32 @@ class _ColorPickerState extends State<_ColorPicker> {
                 final selected = color.value == _selected;
                 return GestureDetector(
                   onTap: () => setState(() => _selected = color.value),
-                  child: Container(
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    width: 40,
+                    height: 40,
                     decoration: BoxDecoration(
                       color: color,
-                      shape: BoxShape.circle,
-                      border: selected
-                          ? Border.all(
-                              color: Colors.white,
-                              width: 3,
-                            )
-                          : null,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: selected
+                            ? const Color(0xFF8A2BE2)
+                            : Colors.transparent,
+                        width: 3,
+                      ),
                     ),
                   ),
                 );
               },
             ),
           ),
-          ElevatedButton(
-            onPressed: () => Navigator.pop(context, _selected),
-            child: const Text('Select'),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: () => Navigator.pop(context, _selected),
+              child: const Text('Select'),
+            ),
           ),
-          const SizedBox(height: 8),
         ],
       ),
     );

--- a/lib/features/habits/category_creation_screen.dart
+++ b/lib/features/habits/category_creation_screen.dart
@@ -20,7 +20,7 @@ class _CategoryCreationScreenState extends State<CategoryCreationScreen> {
   }
 
   Future<void> _pickIcon() async {
-    final icon = await showModalBottomSheet<IconData>(
+    final icon = await showDialog<IconData>(
       context: context,
       builder: (context) => const _IconPicker(),
     );
@@ -37,7 +37,16 @@ class _CategoryCreationScreenState extends State<CategoryCreationScreen> {
   Widget build(BuildContext context) {
     final isValid = _nameController.text.trim().isNotEmpty;
     return Scaffold(
-      appBar: AppBar(title: const Text('New Category')),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.close, size: 24),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: const Text('Create Category',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        backgroundColor: Colors.transparent,
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Column(
@@ -54,9 +63,21 @@ class _CategoryCreationScreenState extends State<CategoryCreationScreen> {
               onChanged: (_) => setState(() {}),
             ),
             const Spacer(),
-            ElevatedButton(
-              onPressed: isValid ? _save : null,
-              child: const Text('Create'),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: isValid
+                      ? const Color(0xFF8A2BE2)
+                      : Colors.white24,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                ),
+                onPressed: isValid ? _save : null,
+                child: const Text('Save'),
+              ),
             )
           ],
         ),
@@ -100,26 +121,34 @@ class _IconPickerState extends State<_IconPicker> {
 
   @override
   Widget build(BuildContext context) {
-    return SafeArea(
-      child: Column(
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pick Icon'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+      ),
+      body: Column(
         children: [
           Padding(
             padding: const EdgeInsets.all(8),
             child: TextField(
               controller: _searchController,
               decoration: const InputDecoration(
-                hintText: 'Search icons',
+                hintText: 'Type a search term',
                 prefixIcon: Icon(Icons.search),
               ),
             ),
           ),
           Expanded(
             child: GridView.builder(
-              padding: const EdgeInsets.all(8),
+              padding: const EdgeInsets.all(12),
               gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                crossAxisCount: 6,
-                crossAxisSpacing: 8,
-                mainAxisSpacing: 8,
+                crossAxisCount: 7,
+                crossAxisSpacing: 12,
+                mainAxisSpacing: 12,
               ),
               itemCount: _icons.length,
               itemBuilder: (context, index) {
@@ -127,22 +156,26 @@ class _IconPickerState extends State<_IconPicker> {
                 final selected = icon == _selected;
                 return GestureDetector(
                   onTap: () => setState(() => _selected = icon),
-                  child: Container(
+                  child: AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
                     decoration: BoxDecoration(
-                      color: selected
-                          ? Theme.of(context).colorScheme.primary
-                          : Colors.transparent,
-                      borderRadius: BorderRadius.circular(8),
+                      color: const Color(0xFF1A1A1A),
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(
+                        color: selected
+                            ? const Color(0xFF8A2BE2)
+                            : Colors.transparent,
+                        width: 2,
+                      ),
                     ),
-                    child: Icon(icon,
-                        color: selected ? Colors.white : Colors.white70),
+                    child: Icon(icon, color: Colors.white),
                   ),
                 );
               },
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(8.0),
+            padding: const EdgeInsets.all(16),
             child: ElevatedButton(
               onPressed: () => Navigator.pop(context, _selected),
               child: const Text('Select'),

--- a/lib/features/habits/reminder_screen.dart
+++ b/lib/features/habits/reminder_screen.dart
@@ -45,34 +45,56 @@ class _ReminderScreenState extends State<ReminderScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Reminders')),
-      body: Column(
-        children: [
-          ListTile(
-            title: const Text('Select all'),
-            trailing: Checkbox(
-              value: _selected.length == 7,
-              onChanged: (_) => _toggleAll(),
-            ),
-          ),
-          Expanded(
-            child: ListView.builder(
-              itemCount: 7,
-              itemBuilder: (context, index) {
-                final day = index + 1;
-                return CheckboxListTile(
-                  title: Text(_weekdayName(day)),
-                  value: _selected.contains(day),
-                  onChanged: (_) => _toggle(day),
-                );
-              },
-            ),
-          ),
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.close, size: 24),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: const Text('Reminder',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        backgroundColor: Colors.transparent,
+        actions: [
+          TextButton(
+            onPressed: _toggleAll,
+            child: const Text('Select all'),
+          )
         ],
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _save,
-        child: const Icon(Icons.check),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Wrap(
+          spacing: 8,
+          runSpacing: 8,
+          children: List.generate(7, (i) {
+            final day = i + 1;
+            final selected = _selected.contains(day);
+            return FilterChip(
+              label: Text(_weekdayName(day)),
+              selected: selected,
+              onSelected: (_) => _toggle(day),
+              selectedColor: const Color(0xFF8A2BE2),
+              checkmarkColor: Colors.white,
+            );
+          }),
+        ),
+      ),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF8A2BE2),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+        ),
       ),
     );
   }

--- a/lib/features/habits/streak_goal_screen.dart
+++ b/lib/features/habits/streak_goal_screen.dart
@@ -26,8 +26,17 @@ class _StreakGoalScreenState extends State<StreakGoalScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Streak Goal')),
-      body: Column(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.close, size: 24),
+          onPressed: () => Navigator.pop(context),
+        ),
+        centerTitle: true,
+        title: const Text('Streak Goal',
+            style: TextStyle(fontWeight: FontWeight.bold)),
+        backgroundColor: Colors.transparent,
+      ),
+      body: ListView(
         children: StreakGoal.values
             .map(
               (e) => RadioListTile<StreakGoal>(
@@ -39,9 +48,22 @@ class _StreakGoalScreenState extends State<StreakGoalScreen> {
             )
             .toList(),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _save,
-        child: const Icon(Icons.check),
+      bottomNavigationBar: Padding(
+        padding: const EdgeInsets.all(16),
+        child: SizedBox(
+          width: double.infinity,
+          child: ElevatedButton(
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF8A2BE2),
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
+            ),
+            onPressed: _save,
+            child: const Text('Save'),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- redesign habit CRUD flows with dark theme and purple accents
- add full-screen icon and color pickers
- update category creation, reminder, and streak goal screens
- centralize dark theme in `App`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876236d392c8329a4341b689b8a5c46