### PR TITLE
Implement new HomeScreen widget

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,14 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/data/habit_repository.dart';
 import '../../core/data/models/habit.dart';
-import '../dashboard/heatmap_widget.dart';
-import 'dart:math';
 
-/// Home screen shown when the user has completed onboarding.
-///
-/// Displays an empty state prompting the user to add their first habit.
+/// Home screen displaying the user's habits.
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
 
@@ -17,204 +14,229 @@ class HomeScreen extends StatefulWidget {
 }
 
 class _HomeScreenState extends State<HomeScreen> {
-  late Future<List<Habit>> _habitsFuture;
-  final Map<String, Map<DateTime, int>> _completionData = {};
+  /// Loaded habits.
+  List<Habit> _habits = [];
+
+  /// Completion status for today keyed by habit id.
+  final Map<String, bool> _completed = {};
 
   @override
   void initState() {
     super.initState();
-    _habitsFuture = HabitRepository.loadHabits();
+    loadHabits();
   }
 
-  Future<void> _refresh() async {
-    final habits = await HabitRepository.loadHabits();
+  /// Loads habits and today's completion status from local storage.
+  Future<void> loadHabits() async {
+    final loaded = await HabitRepository.loadHabits();
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final todayKey = '${now.year}-${now.month}-${now.day}';
+    final status = <String, bool>{};
+    for (final habit in loaded) {
+      final key = 'completion_${habit.id}_$todayKey';
+      status[habit.id] = prefs.getBool(key) ?? false;
+    }
     setState(() {
-      _habitsFuture = Future.value(habits);
+      _habits = loaded;
+      _completed
+        ..clear()
+        ..addAll(status);
     });
   }
 
+  /// Toggles today's completion status for [habit].
+  Future<void> _toggleCompletion(Habit habit, bool? value) async {
+    final newValue = value ?? false;
+    final prefs = await SharedPreferences.getInstance();
+    final now = DateTime.now();
+    final todayKey = '${now.year}-${now.month}-${now.day}';
+    final key = 'completion_${habit.id}_$todayKey';
+    await prefs.setBool(key, newValue);
+    setState(() => _completed[habit.id] = newValue);
+  }
+
+  /// Navigates to the habit creation screen and reloads on return.
   Future<void> _goToAddHabit() async {
     await context.push('/add_habit');
-    if (mounted) {
-      _refresh();
-    }
-  }
-
-  Future<void> _editHabit(Habit habit) async {
-    await context.push('/add_habit', extra: habit);
-    if (mounted) {
-      _refresh();
-    }
-  }
-
-  Map<DateTime, int> _generateMockCompletion() {
-    final map = <DateTime, int>{};
-    final now = DateTime.now();
-    final random = Random();
-    for (var i = 0; i < 90; i++) {
-      final day = DateTime(now.year, now.month, now.day).subtract(Duration(days: i));
-      map[day] = random.nextInt(3); // 0-2 completions
-    }
-    return map;
-  }
-
-  bool _completedToday(String id) {
-    final today = DateTime.now();
-    final key = DateTime(today.year, today.month, today.day);
-    final data = _completionData[id];
-    if (data == null) return false;
-    return (data[key] ?? 0) > 0;
-  }
-
-  void _toggleToday(String id, bool? value) {
-    final today = DateTime.now();
-    final key = DateTime(today.year, today.month, today.day);
-    final data = _completionData.putIfAbsent(id, _generateMockCompletion);
-    data[key] = (value ?? false) ? 1 : 0;
-    setState(() {});
+    if (mounted) await loadHabits();
   }
 
   @override
   Widget build(BuildContext context) {
-    const purple = Color(0xFF8A2BE2);
     return Scaffold(
       backgroundColor: const Color(0xFF121212),
+      extendBodyBehindAppBar: false,
+      // AppBar
       appBar: AppBar(
-        backgroundColor: const Color(0xFF121212),
+        backgroundColor: Colors.transparent,
         elevation: 0,
         leading: IconButton(
-          icon: const Icon(Icons.settings, color: Colors.white),
+          icon: const Icon(Icons.settings, size: 24, color: Colors.white),
+          padding: const EdgeInsets.all(16),
           onPressed: () {},
         ),
-        title: RichText(
-          text: const TextSpan(
-            style: TextStyle(
-              fontWeight: FontWeight.bold,
-              fontSize: 20,
-              fontFamily: 'Roboto',
+        centerTitle: true,
+        title: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: const [
+            Text(
+              'Habit',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
             ),
-            children: [
-              TextSpan(text: 'Habit', style: TextStyle(color: Colors.white)),
-              TextSpan(text: 'Hero', style: TextStyle(color: purple)),
-            ],
-          ),
+            Text(
+              'Kit',
+              style: TextStyle(
+                color: Color(0xFF8A2BE2),
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
         ),
         actions: [
+          Container(
+            margin: const EdgeInsets.only(right: 12),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: const Color(0xFF333333),
+              borderRadius: BorderRadius.circular(8),
+            ),
+            child: const Text(
+              'PRO',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
           IconButton(
-            icon: const Icon(Icons.bar_chart, color: Colors.white),
+            icon: const Icon(Icons.bar_chart, size: 24, color: Colors.white),
+            padding: const EdgeInsets.all(12),
             onPressed: () {},
           ),
           IconButton(
-            icon: const Icon(Icons.add_circle_outline, color: Colors.white),
+            icon:
+                const Icon(Icons.add_circle_outline, size: 28, color: Colors.white),
+            padding: const EdgeInsets.all(12),
             onPressed: _goToAddHabit,
           ),
         ],
       ),
-      body: FutureBuilder<List<Habit>>(
-        future: _habitsFuture,
-        builder: (context, snapshot) {
-          final habits = snapshot.data ?? [];
-          if (habits.isEmpty) {
-            return Center(
-              child: Padding(
-                padding: const EdgeInsets.all(24),
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
+      body: RefreshIndicator(
+        onRefresh: loadHabits,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          child: _habits.isEmpty
+              // Empty state
+              ? Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.center,
                   children: [
                     Container(
-                      width: 80,
-                      height: 80,
-                      decoration: BoxDecoration(
+                      width: 60,
+                      height: 60,
+                      decoration: const BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.white.withOpacity(0.1),
+                        color: Color(0xFF1E1E1E),
                       ),
-                      child: const Icon(Icons.add, color: Colors.white, size: 40),
+                      child: const Icon(Icons.add, size: 32, color: Colors.white),
                     ),
-                    const SizedBox(height: 24),
+                    const SizedBox(height: 16),
                     const Text(
                       'No habit found',
                       style: TextStyle(
                         color: Colors.white,
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
+                        fontSize: 18,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                     const SizedBox(height: 8),
                     const Text(
                       'Create a new habit to track your progress',
+                      style: TextStyle(
+                        color: Color(0xFFB0B0B0),
+                        fontSize: 14,
+                      ),
                       textAlign: TextAlign.center,
-                      style: TextStyle(color: Colors.white70),
                     ),
-                    const SizedBox(height: 32),
-                    SizedBox(
-                      width: double.infinity,
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: purple,
-                          foregroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30),
-                          ),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: _goToAddHabit,
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF8A2BE2),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 32, vertical: 12),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(24),
                         ),
-                        onPressed: _goToAddHabit,
-                        child: const Text('Get started'),
+                      ),
+                      child: const Text(
+                        'Get started',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                        ),
                       ),
                     ),
                   ],
-                ),
-              ),
-            );
-          }
-
-          return RefreshIndicator(
-            onRefresh: _refresh,
-            child: ListView.builder(
-              itemCount: habits.length,
-              itemBuilder: (context, index) {
-                final habit = habits[index];
-                final data =
-                    _completionData.putIfAbsent(habit.id, _generateMockCompletion);
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
+                )
+              // Habit list
+              : ListView.separated(
+                  itemCount: _habits.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final habit = _habits[index];
+                    final checked = _completed[habit.id] ?? false;
+                    return Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFF1E1E1E),
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Row(
                         children: [
-                          Icon(
-                            IconData(habit.iconData, fontFamily: 'MaterialIcons'),
-                            color: Color(habit.color),
+                          Container(
+                            width: 40,
+                            height: 40,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Color(habit.color),
+                            ),
+                            child: Icon(
+                              IconData(habit.iconData,
+                                  fontFamily: 'MaterialIcons'),
+                              size: 24,
+                              color: Colors.white,
+                            ),
                           ),
-                          const SizedBox(width: 8),
+                          const SizedBox(width: 12),
                           Expanded(
                             child: Text(
                               habit.name,
                               style: const TextStyle(
-                                  color: Colors.white, fontWeight: FontWeight.bold),
+                                color: Colors.white,
+                                fontSize: 16,
+                                fontWeight: FontWeight.w500,
+                              ),
                             ),
                           ),
                           Checkbox(
-                            value: _completedToday(habit.id),
-                            onChanged: (v) => _toggleToday(habit.id, v),
-                            activeColor: purple,
-                          )
+                            value: checked,
+                            activeColor: const Color(0xFF8A2BE2),
+                            onChanged: (v) => _toggleCompletion(habit, v),
+                          ),
                         ],
                       ),
-                      const SizedBox(height: 8),
-                      HabitHeatmap(
-                        completionData: data,
-                        icon: IconData(habit.iconData, fontFamily: 'MaterialIcons'),
-                        name: habit.name,
-                        showHeader: false,
-                      ),
-                      const Divider(color: Colors.white24),
-                    ],
-                  ),
-                );
-              },
-            ),
-          );
-        },
+                    );
+                  },
+                ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- rewrite `HomeScreen` with new layout and logic
- load habits and completion status from local storage
- enable toggling completion and navigation to add habit screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687627be903c8329856095bfb5eaef9e