### PR TITLE
Add streak tracking service and badges

### DIFF
--- a/lib/core/data/completion_repository.dart
+++ b/lib/core/data/completion_repository.dart
@@ -1,0 +1,26 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Repository for persisting and loading habit completion dates.
+class CompletionRepository {
+  static const _prefix = 'completion_';
+
+  /// Returns sorted unique dates when the habit was completed.
+  Future<List<DateTime>> getCompletionDates(String habitId) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString('$_prefix$habitId');
+    if (data == null) return [];
+    final List list = jsonDecode(data) as List;
+    final dates = list.map((e) => DateTime.parse(e as String)).toList();
+    dates.sort();
+    return dates;
+  }
+
+  /// Saves the provided list of completion [dates] for the habit.
+  Future<void> saveCompletionDates(String habitId, List<DateTime> dates) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = jsonEncode(dates.map((e) => e.toIso8601String()).toList());
+    await prefs.setString('$_prefix$habitId', data);
+  }
+}

--- a/lib/core/data/models/badge.dart
+++ b/lib/core/data/models/badge.dart
@@ -1,0 +1,48 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+
+/// Model representing an achievement badge.
+class Badge {
+  const Badge({
+    required this.id,
+    required this.title,
+    required this.icon,
+    required this.awardedAt,
+  });
+
+  /// Unique badge identifier.
+  final String id;
+
+  /// Display title for the badge.
+  final String title;
+
+  /// Icon shown for the badge.
+  final IconData icon;
+
+  /// Date when the badge was awarded.
+  final DateTime awardedAt;
+
+  /// Creates a [Badge] from a JSON map.
+  factory Badge.fromMap(Map<String, dynamic> map) => Badge(
+        id: map['id'] as String,
+        title: map['title'] as String,
+        icon: IconData(map['icon'] as int, fontFamily: 'MaterialIcons'),
+        awardedAt: DateTime.parse(map['awardedAt'] as String),
+      );
+
+  /// Converts this [Badge] to a JSON map.
+  Map<String, dynamic> toMap() => {
+        'id': id,
+        'title': title,
+        'icon': icon.codePoint,
+        'awardedAt': awardedAt.toIso8601String(),
+      };
+
+  /// Converts this [Badge] to JSON string.
+  String toJson() => jsonEncode(toMap());
+
+  /// Creates a [Badge] from JSON string.
+  factory Badge.fromJson(String json) =>
+      Badge.fromMap(jsonDecode(json) as Map<String, dynamic>);
+}

--- a/lib/core/streak/streak_service.dart
+++ b/lib/core/streak/streak_service.dart
@@ -1,0 +1,49 @@
+import '../data/completion_repository.dart';
+
+/// Service calculating habit streaks.
+class StreakService {
+  /// Creates a [StreakService] with the provided [CompletionRepository].
+  StreakService(this._repo);
+
+  final CompletionRepository _repo;
+
+  /// Returns the number of consecutive days the habit has been completed
+  /// ending today.
+  Future<int> getCurrentStreak(String habitId) async {
+    final dates = await _repo.getCompletionDates(habitId);
+    dates.sort();
+    if (dates.isEmpty) return 0;
+    var streak = 0;
+    var day = DateTime.now();
+    for (var i = dates.length - 1; i >= 0; i--) {
+      final d = DateTime(dates[i].year, dates[i].month, dates[i].day);
+      if (d.isAtSameMomentAs(DateTime(day.year, day.month, day.day))) {
+        streak++;
+        day = day.subtract(const Duration(days: 1));
+      } else {
+        break;
+      }
+    }
+    return streak;
+  }
+
+  /// Returns the longest run of consecutive completion days for the habit.
+  Future<int> getLongestStreak(String habitId) async {
+    final dates = await _repo.getCompletionDates(habitId);
+    dates.sort();
+    if (dates.isEmpty) return 0;
+    var longest = 1;
+    var current = 1;
+    for (var i = 1; i < dates.length; i++) {
+      final prev = DateTime(dates[i - 1].year, dates[i - 1].month, dates[i - 1].day);
+      final cur = DateTime(dates[i].year, dates[i].month, dates[i].day);
+      if (cur.difference(prev).inDays == 1) {
+        current++;
+        if (current > longest) longest = current;
+      } else if (!cur.isAtSameMomentAs(prev)) {
+        current = 1;
+      }
+    }
+    return longest;
+  }
+}

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+import '../../core/data/models/habit.dart';
+import '../dashboard/heatmap_widget.dart';
+
+/// List item widget displaying a habit with its current streak.
+class HabitItemWidget extends StatelessWidget {
+  const HabitItemWidget({
+    super.key,
+    required this.habit,
+    required this.completionData,
+    required this.completedToday,
+    required this.onToggle,
+    this.currentStreak,
+    this.longestStreak,
+  });
+
+  /// Habit being displayed.
+  final Habit habit;
+
+  /// Map of completion dates used for the heatmap.
+  final Map<DateTime, int> completionData;
+
+  /// Whether the habit is completed today.
+  final bool completedToday;
+
+  /// Callback when today's completion state changes.
+  final ValueChanged<bool?> onToggle;
+
+  /// Current streak count.
+  final int? currentStreak;
+
+  /// Longest streak count.
+  final int? longestStreak;
+
+  @override
+  Widget build(BuildContext context) {
+    const purple = Color(0xFF8A2BE2);
+    final icon = IconData(habit.iconData, fontFamily: 'MaterialIcons');
+    final showBadge = currentStreak != null &&
+        (currentStreak == 7 || currentStreak == 30 || currentStreak == 100);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Stack(
+                children: [
+                  Container(
+                    width: 24,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: Color(habit.color),
+                    ),
+                    child: Icon(icon, color: Colors.white, size: 16),
+                  ),
+                  if (showBadge)
+                    const Positioned(
+                      right: -2,
+                      bottom: -2,
+                      child: Icon(
+                        Icons.emoji_events,
+                        size: 12,
+                        color: Colors.amber,
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  habit.name,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              if (currentStreak != null)
+                Row(
+                  children: [
+                    const Icon(
+                      Icons.local_fire_department,
+                      size: 16,
+                      color: purple,
+                    ),
+                    const SizedBox(width: 2),
+                    Text(
+                      '$currentStreak',
+                      style: const TextStyle(color: Colors.white, fontSize: 12),
+                    ),
+                    const SizedBox(width: 8),
+                  ],
+                ),
+              Checkbox(
+                value: completedToday,
+                onChanged: onToggle,
+                activeColor: purple,
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          HabitHeatmap(
+            completionData: completionData,
+            icon: icon,
+            name: habit.name,
+            showHeader: false,
+          ),
+          const Divider(color: Colors.white24),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -3,8 +3,12 @@ import 'package:go_router/go_router.dart';
 
 import '../../core/data/habit_repository.dart';
 import '../../core/data/models/habit.dart';
+import '../../core/streak/streak_service.dart';
+import '../../core/data/models/badge.dart';
 import '../dashboard/heatmap_widget.dart';
+import 'package:get_it/get_it.dart';
 import 'dart:math';
+import '../habits/habit_item_widget.dart';
 
 /// Home screen shown when the user has completed onboarding.
 ///
@@ -19,15 +23,29 @@ class HomeScreen extends StatefulWidget {
 class _HomeScreenState extends State<HomeScreen> {
   late Future<List<Habit>> _habitsFuture;
   final Map<String, Map<DateTime, int>> _completionData = {};
+  final Map<String, int> _currentStreaks = {};
+  final Map<String, int> _longestStreaks = {};
 
   @override
   void initState() {
     super.initState();
-    _habitsFuture = HabitRepository.loadHabits();
+    _habitsFuture = _loadAndCompute();
+  }
+
+  Future<List<Habit>> _loadAndCompute() async {
+    final habits = await HabitRepository.loadHabits();
+    final service = GetIt.I<StreakService>();
+    for (final habit in habits) {
+      final cs = await service.getCurrentStreak(habit.id);
+      final ls = await service.getLongestStreak(habit.id);
+      _currentStreaks[habit.id] = cs;
+      _longestStreaks[habit.id] = ls;
+    }
+    return habits;
   }
 
   Future<void> _refresh() async {
-    final habits = await HabitRepository.loadHabits();
+    final habits = await _loadAndCompute();
     setState(() {
       _habitsFuture = Future.value(habits);
     });
@@ -174,42 +192,15 @@ class _HomeScreenState extends State<HomeScreen> {
                 final habit = habits[index];
                 final data =
                     _completionData.putIfAbsent(habit.id, _generateMockCompletion);
-                return Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Icon(
-                            IconData(habit.iconData, fontFamily: 'MaterialIcons'),
-                            color: Color(habit.color),
-                          ),
-                          const SizedBox(width: 8),
-                          Expanded(
-                            child: Text(
-                              habit.name,
-                              style: const TextStyle(
-                                  color: Colors.white, fontWeight: FontWeight.bold),
-                            ),
-                          ),
-                          Checkbox(
-                            value: _completedToday(habit.id),
-                            onChanged: (v) => _toggleToday(habit.id, v),
-                            activeColor: purple,
-                          )
-                        ],
-                      ),
-                      const SizedBox(height: 8),
-                      HabitHeatmap(
-                        completionData: data,
-                        icon: IconData(habit.iconData, fontFamily: 'MaterialIcons'),
-                        name: habit.name,
-                        showHeader: false,
-                      ),
-                      const Divider(color: Colors.white24),
-                    ],
-                  ),
+                final current = _currentStreaks[habit.id];
+                final longest = _longestStreaks[habit.id];
+                return HabitItemWidget(
+                  habit: habit,
+                  completionData: data,
+                  completedToday: _completedToday(habit.id),
+                  onToggle: (v) => _toggleToday(habit.id, v),
+                  currentStreak: current,
+                  longestStreak: longest,
                 );
               },
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:get_it/get_it.dart';
 import 'app.dart';
+import 'core/data/completion_repository.dart';
+import 'core/streak/streak_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final getIt = GetIt.instance;
+  getIt.registerLazySingleton<CompletionRepository>(() => CompletionRepository());
+  getIt.registerLazySingleton<StreakService>(
+      () => StreakService(getIt<CompletionRepository>()));
   final prefs = await SharedPreferences.getInstance();
   final completed = prefs.getBool('onboarding_complete') ?? false;
   runApp(App(onboardingComplete: completed));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   shared_preferences: ^2.2.2
   go_router: ^13.2.0
   uuid: ^3.0.7
+  get_it: ^7.6.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- implement `StreakService` for streak calculations
- create `CompletionRepository` for completion persistence
- add `Badge` model
- integrate GetIt in `main.dart`
- display streak counts in home screen using new `HabitItemWidget`
- update dependencies for `get_it`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687629e038a48329bdf537f534807711