### PR TITLE
Implement completion tracking in heatmap

### DIFF
--- a/lib/core/data/completion_repository.dart
+++ b/lib/core/data/completion_repository.dart
@@ -23,4 +23,31 @@ class CompletionRepository {
     final data = jsonEncode(dates.map((e) => e.toIso8601String()).toList());
     await prefs.setString('$_prefix$habitId', data);
   }
+
+  /// Adds or removes [date] from the stored completion dates for [habitId].
+  /// If a completion already exists for that day it is removed, otherwise it
+  /// is added.
+  Future<void> toggleCompletion(String habitId, DateTime date) async {
+    final dates = await getCompletionDates(habitId);
+    final day = DateTime(date.year, date.month, date.day);
+    final index = dates.indexWhere((d) =>
+        d.year == day.year && d.month == day.month && d.day == day.day);
+    if (index >= 0) {
+      dates.removeAt(index);
+    } else {
+      dates.add(day);
+    }
+    await saveCompletionDates(habitId, dates);
+  }
+
+  /// Returns a map of completion counts keyed by date for [habitId].
+  Future<Map<DateTime, int>> getCompletionMap(String habitId) async {
+    final dates = await getCompletionDates(habitId);
+    final map = <DateTime, int>{};
+    for (final d in dates) {
+      final key = DateTime(d.year, d.month, d.day);
+      map[key] = (map[key] ?? 0) + 1;
+    }
+    return map;
+  }
 }

--- a/lib/features/dashboard/heatmap_widget.dart
+++ b/lib/features/dashboard/heatmap_widget.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 /// habit completion over the past [days] days.
 class HabitHeatmap extends StatelessWidget {
   /// Map of dates to completion counts.
-  final Map<DateTime, int> completionData;
+  final Map<DateTime, int> completionMap;
 
   /// Icon representing the habit.
   final IconData icon;
@@ -15,7 +15,7 @@ class HabitHeatmap extends StatelessWidget {
   final String name;
 
   /// Base color used for completion tiles.
-  final Color tileColor;
+  final Color fillColor;
 
   /// Number of days to show, defaults to 90.
   final int days;
@@ -25,28 +25,28 @@ class HabitHeatmap extends StatelessWidget {
 
   const HabitHeatmap({
     super.key,
-    required this.completionData,
+    required this.completionMap,
     required this.icon,
     required this.name,
-    required this.tileColor,
+    required this.fillColor,
     this.days = 90,
     this.showHeader = true,
   });
 
-  /// Returns a color ranging from a light variant of [tileColor] to the full
+  /// Returns a color ranging from a light variant of [fillColor] to the full
   /// color based on [count].
   Color _colorForCount(int count, int maxCount) {
     if (count == 0) {
-      return tileColor.withOpacity(0.2);
+      return fillColor.withOpacity(0.2);
     }
     final t = maxCount == 0 ? 1.0 : count / maxCount;
-    return Color.lerp(tileColor.withOpacity(0.5), tileColor, t)!;
+    return Color.lerp(fillColor.withOpacity(0.5), fillColor, t)!;
   }
 
   @override
   Widget build(BuildContext context) {
     final maxCount =
-        completionData.values.isEmpty ? 0 : completionData.values.reduce(math.max);
+        completionMap.values.isEmpty ? 0 : completionMap.values.reduce(math.max);
     final today = DateTime.now();
     final start = DateTime(today.year, today.month, today.day)
         .subtract(Duration(days: days - 1));
@@ -60,9 +60,17 @@ class HabitHeatmap extends StatelessWidget {
         if (index >= days) break;
         final date = start.add(Duration(days: index));
         final key = DateTime(date.year, date.month, date.day);
-        final count = completionData[key] ?? 0;
-        final color =
-            count > 0 ? _colorForCount(count, maxCount) : tileColor.withOpacity(0.1);
+        final count = completionMap[key] ?? 0;
+        Color squareColor;
+        final isToday = key.year == today.year &&
+            key.month == today.month &&
+            key.day == today.day;
+        if (isToday && count > 0) {
+          squareColor = fillColor;
+        } else {
+          squareColor =
+              count > 0 ? _colorForCount(count, maxCount) : fillColor.withOpacity(0.1);
+        }
         final message = '${key.toIso8601String().split('T').first}: $count';
         squares.add(GestureDetector(
           onTap: () {
@@ -82,7 +90,7 @@ class HabitHeatmap extends StatelessWidget {
               height: 16,
               margin: const EdgeInsets.all(2),
               decoration: BoxDecoration(
-                color: color,
+                color: squareColor,
                 borderRadius: BorderRadius.circular(3),
               ),
             ),

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -25,7 +25,7 @@ class HabitItemWidget extends StatelessWidget {
   final bool completedToday;
 
   /// Callback when today's completion state changes.
-  final ValueChanged<bool?> onToggle;
+  final VoidCallback onToggle;
 
   /// Current streak count.
   final int? currentStreak;
@@ -96,18 +96,23 @@ class HabitItemWidget extends StatelessWidget {
                     const SizedBox(width: 8),
                   ],
                 ),
-              Checkbox(
-                value: completedToday,
-                onChanged: onToggle,
-                activeColor: purple,
+              IconButton(
+                icon: Icon(
+                  completedToday
+                      ? Icons.check_circle
+                      : Icons.check_circle_outline,
+                  color: completedToday ? Colors.white : Colors.grey,
+                ),
+                onPressed: onToggle,
               ),
             ],
           ),
           const SizedBox(height: 8),
           HabitHeatmap(
-            completionData: completionData,
+            completionMap: completionData,
             icon: icon,
             name: habit.name,
+            fillColor: Color(habit.color),
             showHeader: false,
           ),
           const Divider(color: Colors.white24),


### PR DESCRIPTION
## Summary
- handle completion state with CompletionRepository
- enable toggling today's completion via HabitItemWidget
- color today's heatmap square when completed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68762c18722083298a50714f0012dbcc