### PR TITLE
Fix home refresh and heatmap color

### DIFF
--- a/lib/features/dashboard/heatmap_widget.dart
+++ b/lib/features/dashboard/heatmap_widget.dart
@@ -36,9 +36,6 @@ class HabitHeatmap extends StatelessWidget {
   /// Returns a color ranging from a light variant of [tileColor] to the full
   /// color based on [count].
   Color _colorForCount(int count, int maxCount) {
-    if (count == 0) {
-      return tileColor.withOpacity(0.2);
-    }
     final t = maxCount == 0 ? 1.0 : count / maxCount;
     return Color.lerp(tileColor.withOpacity(0.5), tileColor, t)!;
   }
@@ -62,7 +59,7 @@ class HabitHeatmap extends StatelessWidget {
         final key = DateTime(date.year, date.month, date.day);
         final count = completionData[key] ?? 0;
         final color =
-            count > 0 ? _colorForCount(count, maxCount) : tileColor.withOpacity(0.1);
+            count > 0 ? _colorForCount(count, maxCount) : const Color(0xFF1E1E1E);
         final message = '${key.toIso8601String().split('T').first}: $count';
         squares.add(GestureDetector(
           onTap: () {

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -204,7 +204,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
     } else {
       await notificationService.cancelHabitReminders(habit.id);
     }
-    if (mounted) context.go('/home');
+    if (mounted) context.pop(true);
   }
 
   @override


### PR DESCRIPTION
## Summary
- ensure Add/Edit habit screen pops with a result so the home screen refreshes
- remove use of tile color for empty heatmap cells

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687632345cb08329944a0e374ee7b79d