### PR TITLE
Fix minSdkVersion for awesome_notifications

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,8 @@ android {
         applicationId = "com.example.habit_hero_project"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        // Bump minSdk to meet awesome_notifications requirement
+        minSdk = 23
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName


### PR DESCRIPTION
## Summary
- bump Android minSdk to 23 so `awesome_notifications` builds

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763388ddc4832993015d665a91f3e4