### PR TITLE
Add Settings screen and router updates

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'routes/app_router.dart';
 import 'features/onboarding/onboarding_screen.dart';
 import 'features/home/home_screen.dart';
 import 'features/habits/add_edit_habit_screen.dart';
@@ -15,35 +16,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final router = GoRouter(
-      initialLocation: onboardingComplete ? '/home' : '/onboarding',
-      routes: [
-        GoRoute(
-          path: '/onboarding',
-          builder: (context, state) => const OnboardingScreen(),
-        ),
-        GoRoute(
-          path: '/home',
-          builder: (context, state) => const HomeScreen(),
-        ),
-        GoRoute(
-          path: '/add_habit',
-          builder: (context, state) => AddEditHabitScreen(habit: state.extra as Habit?),
-        ),
-        GoRoute(
-          path: '/create_category',
-          builder: (context, state) => const CategoryCreationScreen(),
-        ),
-        GoRoute(
-          path: '/streak_goal',
-          builder: (context, state) => StreakGoalScreen(current: state.extra as StreakGoal?),
-        ),
-        GoRoute(
-          path: '/reminder',
-          builder: (context, state) => ReminderScreen(current: state.extra as List<int>?),
-        ),
-      ],
-    );
+    final router = createRouter(onboardingComplete);
     final baseDark = ThemeData.dark();
     return MaterialApp.router(
       title: 'Habit Tracker',

--- a/lib/features/archive/archive_screen.dart
+++ b/lib/features/archive/archive_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class ArchiveScreen extends StatelessWidget {
+  const ArchiveScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Archive'),
+        backgroundColor: const Color(0xFF121212),
+      ),
+      body: const Center(
+        child: Text('Archived habits will appear here',
+            style: TextStyle(color: Colors.white)),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -100,7 +100,7 @@ class _HomeScreenState extends State<HomeScreen> {
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.settings, color: Colors.white),
-          onPressed: () {},
+          onPressed: () => context.go('/settings'),
         ),
         title: RichText(
           text: const TextSpan(

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Settings'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => Navigator.pop(context),
+        ),
+        backgroundColor: const Color(0xFF121212),
+        elevation: 0,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        children: [
+          ListTile(
+            leading: const Icon(Icons.archive_outlined, color: Colors.white),
+            title: const Text('Archived Habits',
+                style: TextStyle(color: Colors.white)),
+            subtitle: const Text('View or restore archived habits',
+                style: TextStyle(color: Color(0xFFB0B0B0))),
+            trailing: const Icon(Icons.chevron_right, color: Colors.white),
+            onTap: () => context.go('/archive'),
+          ),
+          const Divider(color: Color(0xFF2A2A2A)),
+          ListTile(
+            leading: const Icon(Icons.color_lens_outlined, color: Colors.white),
+            title: const Text('Theme', style: TextStyle(color: Colors.white)),
+            subtitle: const Text('Theme selector coming soon',
+                style: TextStyle(color: Color(0xFFB0B0B0))),
+            trailing: const Icon(Icons.chevron_right, color: Colors.white),
+            onTap: () {},
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,0 +1,54 @@
+import 'package:go_router/go_router.dart';
+import '../features/onboarding/onboarding_screen.dart';
+import '../features/home/home_screen.dart';
+import '../features/habits/add_edit_habit_screen.dart';
+import '../features/habits/category_creation_screen.dart';
+import '../features/habits/streak_goal_screen.dart';
+import '../features/habits/reminder_screen.dart';
+import '../features/archive/archive_screen.dart';
+import '../features/settings/settings_screen.dart';
+import '../core/data/models/habit.dart';
+
+GoRouter createRouter(bool onboardingComplete) {
+  return GoRouter(
+    initialLocation: onboardingComplete ? '/home' : '/onboarding',
+    routes: [
+      GoRoute(
+        path: '/onboarding',
+        builder: (context, state) => const OnboardingScreen(),
+      ),
+      GoRoute(
+        path: '/home',
+        builder: (context, state) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: '/add_habit',
+        builder: (context, state) =>
+            AddEditHabitScreen(habit: state.extra as Habit?),
+      ),
+      GoRoute(
+        path: '/create_category',
+        builder: (context, state) => const CategoryCreationScreen(),
+      ),
+      GoRoute(
+        path: '/streak_goal',
+        builder: (context, state) =>
+            StreakGoalScreen(current: state.extra as StreakGoal?),
+      ),
+      GoRoute(
+        path: '/reminder',
+        builder: (context, state) =>
+            ReminderScreen(current: state.extra as List<int>?),
+      ),
+      GoRoute(
+        path: '/archive',
+        builder: (context, state) => const ArchiveScreen(),
+      ),
+      GoRoute(
+        path: '/settings',
+        name: 'settings',
+        builder: (_, __) => const SettingsScreen(),
+      ),
+    ],
+  );
+}


### PR DESCRIPTION
## Summary
- add new SettingsScreen with dark theme
- implement placeholder ArchiveScreen
- create `app_router.dart` with routes including `/settings`
- update HomeScreen to navigate to Settings
- wire new router into App

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687633b385448329b12d7abb8bacb563