### PR TITLE
Implement calendar tap and reminder setup

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -12,11 +12,12 @@ import 'core/data/models/habit.dart';
 /// Root app widget
 class App extends StatelessWidget {
   final bool onboardingComplete;
-  const App({super.key, required this.onboardingComplete});
+  final GlobalKey<NavigatorState> navigatorKey;
+  const App({super.key, required this.onboardingComplete, required this.navigatorKey});
 
   @override
   Widget build(BuildContext context) {
-    final router = createRouter(onboardingComplete);
+    final router = createRouter(onboardingComplete, navigatorKey);
     final baseDark = ThemeData.dark();
     return MaterialApp.router(
       title: 'Habit Tracker',

--- a/lib/core/services/di.dart
+++ b/lib/core/services/di.dart
@@ -1,8 +1,12 @@
 import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import 'notification_service.dart';
+import 'notification_permission_service.dart';
 
 /// Registers app services in the provided [getIt] instance.
-void registerServices(GetIt getIt) {
+void registerServices(GetIt getIt, SharedPreferences prefs) {
   getIt.registerLazySingleton<NotificationService>(() => NotificationService());
+  getIt.registerLazySingleton<NotificationPermissionService>(
+      () => NotificationPermissionService(prefs));
 }

--- a/lib/core/services/notification_permission_service.dart
+++ b/lib/core/services/notification_permission_service.dart
@@ -1,0 +1,21 @@
+import 'package:awesome_notifications/awesome_notifications.dart';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class NotificationPermissionService {
+  final SharedPreferences prefs;
+  NotificationPermissionService(this.prefs);
+
+  static const _key = 'notifications_requested';
+
+  Future<void> ensurePermissionRequested(BuildContext context) async {
+    final requested = prefs.getBool(_key) ?? false;
+    if (!requested) {
+      final allowed = await AwesomeNotifications().isNotificationAllowed();
+      if (!allowed) {
+        await AwesomeNotifications().requestPermissionToSendNotifications();
+      }
+      await prefs.setBool(_key, true);
+    }
+  }
+}

--- a/lib/features/dashboard/heatmap_widget.dart
+++ b/lib/features/dashboard/heatmap_widget.dart
@@ -23,12 +23,16 @@ class HabitHeatmap extends StatelessWidget {
   /// Whether to show the icon and name above the heatmap.
   final bool showHeader;
 
+  /// Callback when a day square is tapped.
+  final void Function(DateTime tappedDay)? onDayTapped;
+
   const HabitHeatmap({
     super.key,
     required this.completionData,
     required this.icon,
     required this.name,
     required this.tileColor,
+    required this.onDayTapped,
     this.days = 90,
     this.showHeader = true,
   });
@@ -71,6 +75,7 @@ class HabitHeatmap extends StatelessWidget {
                   duration: const Duration(seconds: 1),
                 ),
               );
+            onDayTapped?.call(key);
           },
           child: Tooltip(
             message: message,

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -11,6 +11,7 @@ class HabitItemWidget extends StatelessWidget {
     required this.completionData,
     required this.completedToday,
     required this.onToggle,
+    required this.onDayTapped,
     this.onEdit,
     this.currentStreak,
     this.longestStreak,
@@ -30,6 +31,9 @@ class HabitItemWidget extends StatelessWidget {
 
   /// Callback when the habit should be edited.
   final VoidCallback? onEdit;
+
+  /// Callback when a heatmap day is tapped.
+  final void Function(DateTime)? onDayTapped;
 
   /// Current streak count.
   final int? currentStreak;
@@ -119,6 +123,7 @@ class HabitItemWidget extends StatelessWidget {
             name: habit.name,
             tileColor: Color(habit.color),
             showHeader: false,
+            onDayTapped: onDayTapped,
           ),
           const Divider(color: Colors.white24),
         ],

--- a/lib/features/habits/reminder_setup_screen.dart
+++ b/lib/features/habits/reminder_setup_screen.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+class ReminderSetupScreen extends StatefulWidget {
+  const ReminderSetupScreen({
+    super.key,
+    this.initialTime,
+    required this.initialWeekdays,
+  });
+
+  final TimeOfDay? initialTime;
+  final List<int> initialWeekdays;
+
+  @override
+  State<ReminderSetupScreen> createState() => _ReminderSetupScreenState();
+}
+
+class _ReminderSetupScreenState extends State<ReminderSetupScreen> {
+  TimeOfDay? _time;
+  late List<int> _weekdays;
+
+  @override
+  void initState() {
+    super.initState();
+    _time = widget.initialTime;
+    _weekdays = List<int>.from(widget.initialWeekdays);
+  }
+
+  void _toggleDay(int day) {
+    setState(() {
+      if (_weekdays.contains(day)) {
+        _weekdays.remove(day);
+      } else {
+        _weekdays.add(day);
+      }
+    });
+  }
+
+  Future<void> _pickTime() async {
+    final result = await showTimePicker(
+      context: context,
+      initialTime: _time ?? TimeOfDay.now(),
+    );
+    if (result != null) setState(() => _time = result);
+  }
+
+  String get _previewText {
+    if (_weekdays.isEmpty || _time == null) return 'None';
+    final days = _weekdays
+        .map((d) => ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][d - 1])
+        .join(', ');
+    return 'Reminder set for ${_time!.format(context)} on $days';
+  }
+
+  void _save() {
+    Navigator.pop(context, {'time': _time, 'weekdays': _weekdays});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    const purple = Color(0xFF8A2BE2);
+    return Scaffold(
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        title: const Text('Set Reminder'),
+        leading: IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      backgroundColor: const Color(0xFF121212),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: List.generate(7, (i) {
+                final day = i + 1;
+                final label = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'][i];
+                final selected = _weekdays.contains(day);
+                return ChoiceChip(
+                  label: Text(label),
+                  selected: selected,
+                  selectedColor: purple,
+                  onSelected: (_) => _toggleDay(day),
+                );
+              }),
+            ),
+            const SizedBox(height: 16),
+            if (_weekdays.isNotEmpty)
+              ElevatedButton(
+                onPressed: _pickTime,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: purple,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(30),
+                  ),
+                ),
+                child: Text(_time == null ? 'Pick time' : _time!.format(context)),
+              ),
+            const SizedBox(height: 16),
+            Text(
+              _previewText,
+              style: const TextStyle(color: Colors.white),
+            ),
+            const Spacer(),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _save,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: purple,
+                  foregroundColor: Colors.white,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(20),
+                  ),
+                ),
+                child: const Text('Save'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -201,6 +201,13 @@ class _HomeScreenState extends State<HomeScreen> {
                   currentStreak: current,
                   longestStreak: longest,
                   onEdit: () => _editHabit(habit),
+                  onDayTapped: (day) {
+                    context.push('/calendar_edit', extra: {
+                      'habitId': habit.id,
+                      'habitName': habit.name,
+                      'completionMap': data,
+                    });
+                  },
                 );
               },
             ),

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -1,16 +1,20 @@
 import 'package:go_router/go_router.dart';
+import 'package:flutter/material.dart';
 import '../features/onboarding/onboarding_screen.dart';
 import '../features/home/home_screen.dart';
 import '../features/habits/add_edit_habit_screen.dart';
 import '../features/habits/category_creation_screen.dart';
 import '../features/habits/streak_goal_screen.dart';
 import '../features/habits/reminder_screen.dart';
+import '../features/habits/reminder_setup_screen.dart';
+import '../features/calendar/calendar_edit_screen.dart';
 import '../features/archive/archive_screen.dart';
 import '../features/settings/settings_screen.dart';
 import '../core/data/models/habit.dart';
 
-GoRouter createRouter(bool onboardingComplete) {
+GoRouter createRouter(bool onboardingComplete, GlobalKey<NavigatorState> key) {
   return GoRouter(
+    navigatorKey: key,
     initialLocation: onboardingComplete ? '/home' : '/onboarding',
     routes: [
       GoRoute(
@@ -39,6 +43,29 @@ GoRouter createRouter(bool onboardingComplete) {
         path: '/reminder',
         builder: (context, state) =>
             ReminderScreen(current: state.extra as List<int>?),
+      ),
+      GoRoute(
+        path: '/calendar_edit',
+        name: 'calendar_edit',
+        builder: (_, state) {
+          final args = state.extra! as Map<String, dynamic>;
+          return CalendarEditScreen(
+            habitId: args['habitId'],
+            habitName: args['habitName'],
+            completionMap: args['completionMap'],
+          );
+        },
+      ),
+      GoRoute(
+        path: '/reminder_setup',
+        builder: (_, state) {
+          final extra = state.extra! as Map<String, dynamic>;
+          return ReminderSetupScreen(
+            initialTime: extra['initialTime'] as TimeOfDay?,
+            initialWeekdays:
+                List<int>.from(extra['initialWeekdays'] as List<dynamic>),
+          );
+        },
       ),
       GoRoute(
         path: '/archive',


### PR DESCRIPTION
## Summary
- open calendar edit when tapping heatmap cells
- move reminder scheduling into new `ReminderSetupScreen`
- request notification permission via new service
- wire new routes and navigator key

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6876391d84d483299361b3aa7ad12037