### PR TITLE
Add theme options screen

### DIFF
--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -47,7 +47,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
           ListTile(
             leading: const Icon(Icons.color_lens_outlined, color: Colors.white),
             title: const Text('Theme', style: TextStyle(color: Colors.white)),
-            subtitle: const Text('Choose between light and dark mode',
+            subtitle: const Text('Choose between system, light and dark mode',
                 style: TextStyle(color: Color(0xFFB0B0B0))),
             trailing: const Icon(Icons.chevron_right, color: Colors.white),
             onTap: () => context.push('/theme'),

--- a/lib/features/settings/theme_screen.dart
+++ b/lib/features/settings/theme_screen.dart
@@ -1,8 +1,20 @@
 import 'package:flutter/material.dart';
 
 /// Simple theme selection screen placeholder.
-class ThemeScreen extends StatelessWidget {
+class ThemeScreen extends StatefulWidget {
   const ThemeScreen({super.key});
+
+  @override
+  State<ThemeScreen> createState() => _ThemeScreenState();
+}
+
+class _ThemeScreenState extends State<ThemeScreen> {
+  ThemeMode _mode = ThemeMode.system;
+
+  void _setMode(ThemeMode? mode) {
+    if (mode == null) return;
+    setState(() => _mode = mode);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -17,12 +29,30 @@ class ThemeScreen extends StatelessWidget {
         backgroundColor: const Color(0xFF121212),
         elevation: 0,
       ),
-      body: const Center(
-        child: Text(
-          'Theme options will be available soon',
-          style: TextStyle(color: Colors.white),
-          textAlign: TextAlign.center,
-        ),
+      body: Column(
+        children: [
+          RadioListTile<ThemeMode>(
+            value: ThemeMode.system,
+            groupValue: _mode,
+            onChanged: _setMode,
+            activeColor: Colors.white,
+            title: const Text('System', style: TextStyle(color: Colors.white)),
+          ),
+          RadioListTile<ThemeMode>(
+            value: ThemeMode.light,
+            groupValue: _mode,
+            onChanged: _setMode,
+            activeColor: Colors.white,
+            title: const Text('Light', style: TextStyle(color: Colors.white)),
+          ),
+          RadioListTile<ThemeMode>(
+            value: ThemeMode.dark,
+            groupValue: _mode,
+            onChanged: _setMode,
+            activeColor: Colors.white,
+            title: const Text('Dark', style: TextStyle(color: Colors.white)),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add basic theme options in theme screen
- tweak settings tab subtitle to mention all three themes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763ce33f448329bd4bbe0379dbc3f0