### PR TITLE
Fix duplicate arguments in router

### DIFF
--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -82,14 +82,13 @@ GoRouter createRouter(bool onboardingComplete, GlobalKey<NavigatorState> key) {
         builder: (_, __) => const SettingsScreen(),
       ),
       GoRoute(
-
         path: '/backup_restore',
         name: 'backup_restore',
         builder: (_, __) => const ExportImportScreen(),
-
+      ),
+      GoRoute(
         path: '/theme',
         builder: (_, __) => const ThemeScreen(),
-
       ),
     ],
   );


### PR DESCRIPTION
## Summary
- fix duplicated `path` and `builder` arguments in `app_router.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763d3695308329ad22a6198b6742e8