### PR TITLE
Fix HomeScreen completion map arg

### DIFF
--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -228,8 +228,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 for (final habit in habits)
                   HabitItemWidget(
                     habit: habit,
-                    completionData:
-                        _completionData.putIfAbsent(habit.id, _generateMockCompletion),
+                    completionMap: _completionData[habit.id] ?? {},
                     completedToday: _completedToday(habit.id),
                     onToggle: (v) => _toggleToday(habit.id, v),
                     currentStreak: _currentStreaks[habit.id],


### PR DESCRIPTION
## Summary
- fix parameter name from `completionData` to `completionMap`
- provide default empty map instead of undefined function

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687640b689488329b7e810bfb74f77b0