### PR TITLE
Implement multiple completion tracking

### DIFF
--- a/lib/core/data/completion_repository.dart
+++ b/lib/core/data/completion_repository.dart
@@ -1,52 +1,95 @@
 import 'dart:convert';
 
+import 'package:intl/intl.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-/// Repository for persisting and loading habit completion dates.
+/// Repository for persisting and loading habit completion timestamps.
 class CompletionRepository {
   static const _prefix = 'completion_';
+  final DateFormat _fmt = DateFormat('yyyy-MM-dd');
 
-  /// Returns sorted unique dates when the habit was completed.
-  Future<List<DateTime>> getCompletionDates(String habitId) async {
+  Future<Map<String, List<String>>> _load(String habitId) async {
     final prefs = await SharedPreferences.getInstance();
     final data = prefs.getString('$_prefix$habitId');
-    if (data == null) return [];
-    final List list = jsonDecode(data) as List;
-    final dates = list.map((e) => DateTime.parse(e as String)).toList();
+    if (data == null) return {};
+    final decoded = jsonDecode(data) as Map<String, dynamic>;
+    return decoded.map(
+        (k, v) => MapEntry(k, List<String>.from(v as List<dynamic>)));
+  }
+
+  Future<void> _save(String habitId, Map<String, List<String>> map) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('$_prefix$habitId', jsonEncode(map));
+  }
+
+  /// Returns every saved completion timestamp for the habit.
+  Future<List<DateTime>> getCompletionDates(String habitId) async {
+    final map = await _load(habitId);
+    final dates = <DateTime>[];
+    for (final list in map.values) {
+      for (final ts in list) {
+        dates.add(DateTime.parse(ts as String));
+      }
+    }
     dates.sort();
     return dates;
   }
 
   /// Saves the provided list of completion [dates] for the habit.
   Future<void> saveCompletionDates(String habitId, List<DateTime> dates) async {
-    final prefs = await SharedPreferences.getInstance();
-    final data = jsonEncode(dates.map((e) => e.toIso8601String()).toList());
-    await prefs.setString('$_prefix$habitId', data);
-  }
-
-  /// Returns a map of completion counts keyed by day.
-  Future<Map<DateTime, int>> getCompletionMap(String habitId) async {
-    final dates = await getCompletionDates(habitId);
-    final map = <DateTime, int>{};
+    final map = <String, List<String>>{};
     for (final d in dates) {
-      final key = DateTime(d.year, d.month, d.day);
-      map[key] = (map[key] ?? 0) + 1;
+      final key = _fmt.format(d.toUtc());
+      final list = map.putIfAbsent(key, () => <String>[]);
+      list.add(d.toUtc().toIso8601String());
     }
-    return map;
+    await _save(habitId, map);
   }
 
-  /// Toggles completion state for a [date] of the habit.
+  /// Returns a map of completion counts keyed by day string (yyyy-MM-dd).
+  Future<Map<String, int>> getCompletionMap(String habitId) async {
+    final map = await _load(habitId);
+    return {for (final e in map.entries) e.key: e.value.length};
+  }
+
+  /// Toggles completion state for a [date] of the habit (0/1 legacy).
   Future<void> toggleCompletion(String habitId, DateTime date) async {
-    final dates = await getCompletionDates(habitId);
-    final day = DateTime(date.year, date.month, date.day);
-    final exists = dates.any((d) =>
-        d.year == day.year && d.month == day.month && d.day == day.day);
-    if (exists) {
-      dates.removeWhere((d) =>
-          d.year == day.year && d.month == day.month && d.day == day.day);
+    final map = await _load(habitId);
+    final key = _fmt.format(date.toUtc());
+    if (map.containsKey(key)) {
+      map.remove(key);
     } else {
-      dates.add(day);
+      map[key] = [date.toUtc().toIso8601String()];
     }
-    await saveCompletionDates(habitId, dates);
+    await _save(habitId, map);
+  }
+
+  /// Increment today's completion count.
+  Future<void> incrementToday(String habitId) async {
+    final map = await _load(habitId);
+    final now = DateTime.now().toUtc();
+    final key = _fmt.format(now);
+    final list = map.putIfAbsent(key, () => <String>[]);
+    list.add(now.toIso8601String());
+    await _save(habitId, map);
+  }
+
+  /// Decrement today's completion count.
+  Future<void> decrementToday(String habitId) async {
+    final map = await _load(habitId);
+    final now = DateTime.now().toUtc();
+    final key = _fmt.format(now);
+    final list = map[key];
+    if (list == null || list.isEmpty) return;
+    list.removeLast();
+    if (list.isEmpty) map.remove(key);
+    await _save(habitId, map);
+  }
+
+  /// Returns today's completion count.
+  Future<int> todayCount(String habitId) async {
+    final map = await _load(habitId);
+    final key = _fmt.format(DateTime.now().toUtc());
+    return map[key]?.length ?? 0;
   }
 }

--- a/lib/core/data/repositories/migration_service.dart
+++ b/lib/core/data/repositories/migration_service.dart
@@ -1,0 +1,32 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Migrates old completion data to the new multi-entry format.
+class MigrationService {
+  static const _prefix = 'completion_';
+
+  /// Scans stored completion maps and converts integer counts
+  /// to lists of timestamp strings.
+  Future<void> run() async {
+    final prefs = await SharedPreferences.getInstance();
+    final keys = prefs.getKeys().where((k) => k.startsWith(_prefix));
+    for (final key in keys) {
+      final data = prefs.getString(key);
+      if (data == null) continue;
+      final decoded = jsonDecode(data);
+      if (decoded is Map<String, dynamic> && decoded.values.isNotEmpty) {
+        final first = decoded.values.first;
+        if (first is int) {
+          final newMap = <String, List<String>>{};
+          for (final entry in decoded.entries) {
+            final count = entry.value as int;
+            newMap[entry.key] = List.generate(count, (_) => 'legacy');
+          }
+          await prefs.setString(key, jsonEncode(newMap));
+        }
+      }
+    }
+  }
+}
+

--- a/lib/core/services/export_import_service.dart
+++ b/lib/core/services/export_import_service.dart
@@ -50,7 +50,7 @@ class ExportImportService {
     for (final h in habits) {
       final map = await _completionRepo.getCompletionMap(h.id);
       for (final entry in map.entries) {
-        final dateStr = entry.key.toIso8601String().split('T').first;
+        final dateStr = entry.key;
         rows.add([h.id, h.name, dateStr, entry.value]);
       }
     }

--- a/lib/features/calendar/calendar_edit_screen.dart
+++ b/lib/features/calendar/calendar_edit_screen.dart
@@ -4,7 +4,6 @@ import 'package:table_calendar/table_calendar.dart';
 import 'package:get_it/get_it.dart';
 
 import '../../core/data/completion_repository.dart';
-import '../../core/utils/date_utils.dart';
 
 /// Screen allowing users to back-date or edit habit completions.
 class CalendarEditScreen extends StatefulWidget {
@@ -22,7 +21,7 @@ class CalendarEditScreen extends StatefulWidget {
   final String habitName;
 
   /// Initial map of completion counts for each day.
-  final Map<DateTime, int> completionMap;
+  final Map<String, int> completionMap;
 
   @override
   State<CalendarEditScreen> createState() => _CalendarEditScreenState();
@@ -33,7 +32,7 @@ class _CalendarEditScreenState extends State<CalendarEditScreen> {
 
   late DateTime _focusedDay;
   DateTime? _selectedDay;
-  late Map<DateTime, int> _completionMap;
+  late Map<String, int> _completionMap;
   bool _loading = false;
 
   @override
@@ -67,7 +66,8 @@ class _CalendarEditScreenState extends State<CalendarEditScreen> {
   }
 
   bool _isSelected(DateTime day) {
-    final key = startOfDay(day);
+    final key =
+        '${day.year.toString().padLeft(4, '0')}-${day.month.toString().padLeft(2, '0')}-${day.day.toString().padLeft(2, '0')}';
     return _completionMap[key] != null && _completionMap[key]! > 0;
   }
 

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -9,8 +9,9 @@ class HabitItemWidget extends StatelessWidget {
     super.key,
     required this.habit,
     required this.completionMap,
-    required this.completedToday,
-    required this.onToggle,
+    required this.todayCount,
+    required this.onIncrement,
+    required this.onDecrement,
     required this.onDayTapped,
     this.onEdit,
     this.onLongPress,
@@ -22,13 +23,13 @@ class HabitItemWidget extends StatelessWidget {
   final Habit habit;
 
   /// Map of completion counts per day used for the heatmap.
-  final Map<DateTime, int> completionMap;
+  final Map<String, int> completionMap;
 
-  /// Whether the habit is completed today.
-  final bool completedToday;
+  /// Today's completion count.
+  final int todayCount;
 
-  /// Callback when today's completion state changes.
-  final ValueChanged<bool?> onToggle;
+  final VoidCallback onIncrement;
+  final VoidCallback onDecrement;
 
   /// Callback when the habit should be edited.
   final VoidCallback? onEdit;
@@ -112,10 +113,22 @@ class HabitItemWidget extends StatelessWidget {
                     const SizedBox(width: 8),
                   ],
                 ),
-              Checkbox(
-                value: completedToday,
-                onChanged: onToggle,
-                activeColor: purple,
+              Row(
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.remove, color: Colors.white),
+                    onPressed: todayCount > 0 ? onDecrement : null,
+                  ),
+                  Text(
+                    '$todayCount',
+                    style:
+                        const TextStyle(color: Colors.white, fontSize: 16),
+                  ),
+                  IconButton(
+                    icon: const Icon(Icons.add, color: Colors.white),
+                    onPressed: onIncrement,
+                  ),
+                ],
               ),
               if (onEdit != null)
                 IconButton(
@@ -126,10 +139,12 @@ class HabitItemWidget extends StatelessWidget {
           ),
           const SizedBox(height: 8),
           HabitHeatmap(
-            completionMap: completionMap,
+            dailyCounts: completionMap,
             icon: icon,
             name: habit.name,
             fillColor: Color(habit.color),
+            completionTarget: habit.completionTarget,
+            trackingType: habit.completionTrackingType,
             showHeader: false,
             onDayTapped: onDayTapped,
           ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -12,6 +12,7 @@ import '../../core/analytics/analytics_service.dart';
 import '../../core/services/settings_provider.dart';
 import 'package:provider/provider.dart';
 import '../analytics/analytics_quick_row.dart';
+import 'package:intl/intl.dart';
 
 /// Home screen shown when the user has completed onboarding.
 ///
@@ -25,7 +26,7 @@ class HomeScreen extends StatefulWidget {
 
 class _HomeScreenState extends State<HomeScreen> {
   late Future<List<Habit>> _habitsFuture;
-  final Map<String, Map<DateTime, int>> _completionData = {};
+  final Map<String, Map<String, int>> _completionData = {};
   final Map<String, int> _currentStreaks = {};
   final Map<String, int> _longestStreaks = {};
 
@@ -41,8 +42,8 @@ class _HomeScreenState extends State<HomeScreen> {
     final service = GetIt.I<StreakService>();
     final completionRepo = GetIt.I<CompletionRepository>();
     for (final habit in habits) {
-      final cs = await service.getCurrentStreak(habit.id);
-      final ls = await service.getLongestStreak(habit.id);
+      final cs = await service.getCurrentStreak(habit);
+      final ls = await service.getLongestStreak(habit);
       _currentStreaks[habit.id] = cs;
       _longestStreaks[habit.id] = ls;
       final map = await completionRepo.getCompletionMap(habit.id);
@@ -99,22 +100,39 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
 
-  bool _completedToday(String id) {
-    final today = DateTime.now();
-    final key = DateTime(today.year, today.month, today.day);
+  int _todayCount(String id) {
+    final key = DateFormat('yyyy-MM-dd').format(DateTime.now().toUtc());
     final data = _completionData[id];
-    if (data == null) return false;
-    return (data[key] ?? 0) > 0;
+    if (data == null) return 0;
+    return data[key] ?? 0;
   }
 
-  Future<void> _toggleToday(String id, bool? value) async {
+  Future<void> _incrementToday(String id) async {
     final repo = GetIt.I<CompletionRepository>();
     final service = GetIt.I<StreakService>();
-    final today = DateTime.now();
-    await repo.toggleCompletion(id, today);
+    await repo.incrementToday(id);
     final map = await repo.getCompletionMap(id);
-    final cs = await service.getCurrentStreak(id);
-    final ls = await service.getLongestStreak(id);
+    final habits = await HabitRepository.loadHabits();
+    final habit = habits.firstWhere((h) => h.id == id);
+    final cs = await service.getCurrentStreak(habit);
+    final ls = await service.getLongestStreak(habit);
+    if (!mounted) return;
+    setState(() {
+      _completionData[id] = map;
+      _currentStreaks[id] = cs;
+      _longestStreaks[id] = ls;
+    });
+  }
+
+  Future<void> _decrementToday(String id) async {
+    final repo = GetIt.I<CompletionRepository>();
+    final service = GetIt.I<StreakService>();
+    await repo.decrementToday(id);
+    final map = await repo.getCompletionMap(id);
+    final habits = await HabitRepository.loadHabits();
+    final habit = habits.firstWhere((h) => h.id == id);
+    final cs = await service.getCurrentStreak(habit);
+    final ls = await service.getLongestStreak(habit);
     if (!mounted) return;
     setState(() {
       _completionData[id] = map;
@@ -228,10 +246,11 @@ class _HomeScreenState extends State<HomeScreen> {
                 for (final habit in habits)
                   HabitItemWidget(
                     habit: habit,
-                    completionData:
-                        _completionData.putIfAbsent(habit.id, _generateMockCompletion),
-                    completedToday: _completedToday(habit.id),
-                    onToggle: (v) => _toggleToday(habit.id, v),
+                    completionMap:
+                        _completionData.putIfAbsent(habit.id, () => {}),
+                    todayCount: _todayCount(habit.id),
+                    onIncrement: () => _incrementToday(habit.id),
+                    onDecrement: () => _decrementToday(habit.id),
                     currentStreak: _currentStreaks[habit.id],
                     longestStreak: _longestStreaks[habit.id],
                     onEdit: () => _editHabit(habit),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,7 @@ dependencies:
   path_provider: ^2.0.15
   provider: ^6.0.5
   fl_chart: ^0.65.0
+  intl: ^0.19.0
 
 
 dev_dependencies:

--- a/test/multiple_completion_test.dart
+++ b/test/multiple_completion_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:habit_hero_project/core/data/completion_repository.dart';
+import 'package:habit_hero_project/core/data/habit_repository.dart';
+import 'package:habit_hero_project/core/data/models/habit.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:intl/intl.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  test('increment and decrement today count', () async {
+    final repo = CompletionRepository();
+    final habit = Habit(id: 'h1', name: 'Water', completionTarget: 8);
+    await HabitRepository.addHabit(habit);
+
+    await repo.incrementToday(habit.id);
+    await repo.incrementToday(habit.id);
+    await repo.incrementToday(habit.id);
+    expect(await repo.todayCount(habit.id), 3);
+
+    await repo.decrementToday(habit.id);
+    expect(await repo.todayCount(habit.id), 2);
+
+    final map = await repo.getCompletionMap(habit.id);
+    final key = DateFormat('yyyy-MM-dd').format(DateTime.now().toUtc());
+    expect(map[key], 2);
+  });
+}

--- a/test/new_habit_heatmap_empty_test.dart
+++ b/test/new_habit_heatmap_empty_test.dart
@@ -38,7 +38,7 @@ void main() {
 
     expect(find.byWidgetPredicate(predicate), findsNothing);
 
-    await tester.tap(find.byType(Checkbox));
+    await tester.tap(find.byIcon(Icons.add));
     await tester.pumpAndSettle();
 
     expect(find.byWidgetPredicate(predicate), findsOneWidget);


### PR DESCRIPTION
## Summary
- allow multiple completions per day
- add migration service for old completion data
- update streak and analytics logic to use daily counts
- display stepper controls in habit item
- update heatmap widget for per-day counts
- add tests for new behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876407472048329bf0e038b2c0cc200