### PR TITLE
Add habit template gallery

### DIFF
--- a/assets/templates/drink_water.json
+++ b/assets/templates/drink_water.json
@@ -1,0 +1,9 @@
+{
+  "id": "tpl_drink_water",
+  "name": "Drink 8 Glasses",
+  "description": "Stay hydrated by drinking 8 glasses of water.",
+  "iconData": 0xe0f0,
+  "color": 0xFF0097A7,
+  "completionTrackingType": "customValue",
+  "completionTarget": 8
+}

--- a/assets/templates/miracle_morning.json
+++ b/assets/templates/miracle_morning.json
@@ -1,0 +1,11 @@
+{
+  "id": "tpl_miracle_morning",
+  "name": "Miracle Morning",
+  "description": "Wake up early and follow the SAVERS routine.",
+  "iconData": 0xe038,
+  "color": 0xFF8A2BE2,
+  "reminderTime": {"hour": 6, "minute": 0},
+  "reminderWeekdays": [1,2,3,4,5],
+  "completionTrackingType": "stepByStep",
+  "completionTarget": 1
+}

--- a/assets/templates/pomodoro_study.json
+++ b/assets/templates/pomodoro_study.json
@@ -1,0 +1,11 @@
+{
+  "id": "tpl_pomodoro_study",
+  "name": "Pomodoro Study Session",
+  "description": "25-minute focused study blocks.",
+  "iconData": 0xe042,
+  "color": 0xFFFF7043,
+  "reminderTime": {"hour": 19, "minute": 0},
+  "reminderWeekdays": [1,2,3,4,5],
+  "completionTrackingType": "stepByStep",
+  "completionTarget": 4
+}

--- a/lib/core/data/models/habit_template.dart
+++ b/lib/core/data/models/habit_template.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+class HabitTemplate {
+  final String id;
+  final String name;
+  final String description;
+  final int iconData;
+  final int color;
+  final TimeOfDay? reminderTime;
+  final List<int> reminderWeekdays;
+  final String completionTrackingType;
+  final int completionTarget;
+
+  HabitTemplate({
+    required this.id,
+    required this.name,
+    required this.description,
+    required this.iconData,
+    required this.color,
+    this.reminderTime,
+    this.reminderWeekdays = const [],
+    required this.completionTrackingType,
+    required this.completionTarget,
+  });
+
+  factory HabitTemplate.fromJson(Map<String, dynamic> j) => HabitTemplate(
+        id: j['id'],
+        name: j['name'],
+        description: j['description'],
+        iconData: j['iconData'],
+        color: j['color'],
+        reminderTime: j['reminderTime'] != null
+            ? TimeOfDay(
+                hour: j['reminderTime']['hour'],
+                minute: j['reminderTime']['minute'],
+              )
+            : null,
+        reminderWeekdays:
+            (j['reminderWeekdays'] as List?)?.cast<int>() ?? const [],
+        completionTrackingType: j['completionTrackingType'],
+        completionTarget: j['completionTarget'],
+      );
+}

--- a/lib/core/services/di.dart
+++ b/lib/core/services/di.dart
@@ -8,23 +8,24 @@ import '../data/completion_repository.dart';
 import 'export_import_service.dart';
 import '../analytics/analytics_service.dart';
 import 'settings_provider.dart';
+import 'template_service.dart';
 
 import 'notification_permission_service.dart';
-
 
 /// Registers app services in the provided [getIt] instance.
 void registerServices(GetIt getIt, SharedPreferences prefs) {
   getIt.registerLazySingleton<NotificationService>(() => NotificationService());
 
-  getIt.registerLazySingleton<ExportImportService>(
-      () => ExportImportService(getIt<HabitRepository>(), getIt<CompletionRepository>()));
+  getIt.registerLazySingleton<ExportImportService>(() => ExportImportService(
+      getIt<HabitRepository>(), getIt<CompletionRepository>()));
 
   getIt.registerLazySingleton<NotificationPermissionService>(
       () => NotificationPermissionService(prefs));
 
-  getIt.registerLazySingleton<AnalyticsService>(
-      () => AnalyticsService(getIt<HabitRepository>(), getIt<CompletionRepository>()));
+  getIt.registerLazySingleton<AnalyticsService>(() => AnalyticsService(
+      getIt<HabitRepository>(), getIt<CompletionRepository>()));
 
   getIt.registerLazySingleton<SettingsProvider>(() => SettingsProvider(prefs));
 
+  getIt.registerLazySingleton<TemplateService>(() => TemplateService());
 }

--- a/lib/core/services/template_service.dart
+++ b/lib/core/services/template_service.dart
@@ -1,0 +1,19 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+import '../data/models/habit_template.dart';
+
+class TemplateService {
+  Future<List<HabitTemplate>> loadTemplates() async {
+    final manifest = await rootBundle.loadString('AssetManifest.json');
+    final files = jsonDecode(manifest) as Map<String, dynamic>;
+    final templatePaths = files.keys
+        .where((p) => p.startsWith('assets/templates/') && p.endsWith('.json'))
+        .toList();
+    final templates = <HabitTemplate>[];
+    for (final path in templatePaths) {
+      final data = await rootBundle.loadString(path);
+      templates.add(HabitTemplate.fromJson(jsonDecode(data)));
+    }
+    return templates;
+  }
+}

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -9,6 +9,7 @@ import 'streak_goal_screen.dart';
 import 'package:get_it/get_it.dart';
 import '../../core/services/notification_service.dart';
 import '../../core/services/notification_permission_service.dart';
+import '../../core/data/models/habit_template.dart';
 
 /// Screen for creating or editing a habit.
 class AddEditHabitScreen extends StatefulWidget {
@@ -152,7 +153,6 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
     }
   }
 
-
   /// Navigates to the category creation screen and adds a new category.
   Future<void> _createCategory() async {
     final result = await context.push<String>('/create_category');
@@ -242,6 +242,30 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
+              ElevatedButton.icon(
+                icon: const Icon(Icons.view_module),
+                label: const Text('Browse templates'),
+                onPressed: () async {
+                  final tpl = await context.push<HabitTemplate>('/templates');
+                  if (tpl != null) {
+                    setState(() {
+                      _nameController.text = tpl.name;
+                      _descriptionController.text = tpl.description;
+                      _icon =
+                          IconData(tpl.iconData, fontFamily: 'MaterialIcons');
+                      _color = tpl.color;
+                      _reminderTime = tpl.reminderTime;
+                      _reminderWeekdays = tpl.reminderWeekdays;
+                      _trackingType =
+                          tpl.completionTrackingType == 'customValue'
+                              ? CompletionTrackingType.customValue
+                              : CompletionTrackingType.stepByStep;
+                      _completionTarget = tpl.completionTarget;
+                    });
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
               Center(
                 child: Container(
                   width: 80,
@@ -414,8 +438,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
             Expanded(
               child: ChoiceChip(
                 label: const Text('Step By Step'),
-                selected: _trackingType ==
-                    CompletionTrackingType.stepByStep,
+                selected: _trackingType == CompletionTrackingType.stepByStep,
                 onSelected: (_) => setState(
                     () => _trackingType = CompletionTrackingType.stepByStep),
               ),
@@ -424,8 +447,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
             Expanded(
               child: ChoiceChip(
                 label: const Text('Custom Value'),
-                selected:
-                    _trackingType == CompletionTrackingType.customValue,
+                selected: _trackingType == CompletionTrackingType.customValue,
                 onSelected: (_) => setState(
                     () => _trackingType = CompletionTrackingType.customValue),
               ),
@@ -450,8 +472,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
               ),
               IconButton(
                 icon: const Icon(Icons.add),
-                onPressed: () =>
-                    setState(() => _completionTarget++),
+                onPressed: () => setState(() => _completionTarget++),
               ),
             ],
           ),
@@ -471,7 +492,6 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
       ],
     );
   }
-
 }
 
 /// Simple icon picker with a searchable grid.
@@ -500,9 +520,7 @@ class _IconPickerState extends State<_IconPicker> {
     final query = _searchController.text.toLowerCase();
     setState(() {
       _icons = _allIcons
-          .where((e) => e.codePoint
-              .toString()
-              .contains(query))
+          .where((e) => e.codePoint.toString().contains(query))
           .toList();
     });
   }

--- a/lib/features/templates/template_gallery_screen.dart
+++ b/lib/features/templates/template_gallery_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../core/constants/spacing.dart';
+import '../../core/constants/radii.dart';
+import '../../core/constants/text_styles.dart';
+import '../../core/services/template_service.dart';
+import '../../core/data/models/habit_template.dart';
+import '../../widgets/app_button.dart';
+
+class TemplateGalleryScreen extends StatelessWidget {
+  const TemplateGalleryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final templateService = context.read<TemplateService>();
+    return Scaffold(
+      backgroundColor: const Color(0xFF121212),
+      appBar: AppBar(
+        title: const Text('Templates'),
+        backgroundColor: Colors.transparent,
+        iconTheme: const IconThemeData(color: Colors.white),
+      ),
+      body: FutureBuilder<List<HabitTemplate>>(
+        future: templateService.loadTemplates(),
+        builder: (ctx, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final templates = snapshot.data!;
+          return GridView.builder(
+            padding: const EdgeInsets.all(AppSpacing.s16),
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: AppSpacing.s16,
+              crossAxisSpacing: AppSpacing.s16,
+              childAspectRatio: 3 / 4,
+            ),
+            itemCount: templates.length,
+            itemBuilder: (_, i) {
+              final tpl = templates[i];
+              return GestureDetector(
+                onTap: () => Navigator.pop(ctx, tpl),
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF1E1E1E),
+                    borderRadius: BorderRadius.circular(AppRadii.r12),
+                  ),
+                  padding: const EdgeInsets.all(AppSpacing.s12),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CircleAvatar(
+                        radius: 24,
+                        backgroundColor: Color(tpl.color),
+                        child: Icon(
+                          IconData(tpl.iconData, fontFamily: 'MaterialIcons'),
+                          color: Colors.white,
+                        ),
+                      ),
+                      const SizedBox(height: AppSpacing.s12),
+                      Text(tpl.name,
+                          style: AppTextStyles.headline
+                              .copyWith(fontSize: 16, color: Colors.white)),
+                      const SizedBox(height: AppSpacing.s8),
+                      Expanded(
+                        child: Text(
+                          tpl.description,
+                          style: AppTextStyles.caption,
+                          maxLines: 4,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      AppButton(
+                        label: 'Use',
+                        onPressed: () => Navigator.pop(ctx, tpl),
+                        primary: true,
+                      ),
+                    ],
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/routes/app_router.dart
+++ b/lib/routes/app_router.dart
@@ -15,6 +15,7 @@ import '../features/export_import/export_import_screen.dart';
 
 import '../features/settings/theme_screen.dart';
 import '../features/analytics/analytics_screen.dart';
+import '../features/templates/template_gallery_screen.dart';
 
 import '../core/data/models/habit.dart';
 
@@ -95,6 +96,11 @@ GoRouter createRouter(bool onboardingComplete, GlobalKey<NavigatorState> key) {
         path: '/analytics',
         name: 'analytics',
         builder: (_, __) => const AnalyticsScreen(),
+      ),
+      GoRoute(
+        path: '/templates',
+        name: 'templates',
+        builder: (_, __) => const TemplateGalleryScreen(),
       ),
     ],
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,6 +70,9 @@ flutter:
   # the material Icons class.
   uses-material-design: true
 
+  assets:
+    - assets/templates/
+
   # To add assets to your application, add an assets section, like this:
   # assets:
   #   - images/a_dot_burr.jpeg

--- a/test/template_gallery_test.dart
+++ b/test/template_gallery_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:go_router/go_router.dart';
+import 'package:get_it/get_it.dart';
+
+import 'package:habit_hero_project/routes/app_router.dart';
+import 'package:habit_hero_project/core/services/template_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  final getIt = GetIt.instance;
+
+  setUp(() {
+    getIt.reset();
+    getIt.registerLazySingleton<TemplateService>(() => TemplateService());
+  });
+
+  testWidgets('template fills add habit form', (tester) async {
+    final router = createRouter(true, GlobalKey<NavigatorState>());
+    await tester.pumpWidget(
+      Provider<TemplateService>.value(
+        value: getIt<TemplateService>(),
+        child: MaterialApp.router(routerConfig: router),
+      ),
+    );
+
+    router.go('/add_habit');
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Browse templates'));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Miracle Morning').first);
+    await tester.pumpAndSettle();
+
+    expect(find.widgetWithText(TextField, 'Miracle Morning'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add sample habit template JSON files
- register habit templates in pubspec
- create `HabitTemplate` model and `TemplateService`
- inject `TemplateService` via DI
- implement a template gallery screen
- hook template gallery into router and Add Habit flow
- add widget test for selecting a template

## Testing
- `flutter test` *(fails: The current Dart SDK version is 3.3.3)*

------
https://chatgpt.com/codex/tasks/task_e_687640ee7f3c83298b545b8adc16a15d