### PR TITLE
Update intl dependency for Flutter notifications

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   path_provider: ^2.0.15
   provider: ^6.0.5
   fl_chart: ^0.65.0
-  intl: ^0.19.0
+  intl: ^0.20.2
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- fix intl/awesome_notifications version conflict by bumping intl to `^0.20.2`

## Testing
- `flutter pub get` *(fails: `command not found: flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68764550a9a88329965fefce46ce3a84