### PR TITLE
Introduce style constants and widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Screenshot QA Checklist
+- [ ] Light mode
+- [ ] Dark mode
+- [ ] High contrast

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,8 +21,12 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    - prefer_const_constructors
+    - avoid_redundant_argument_values
+    - avoid_hard_coded_colors
+    - prefer_const_literals_to_create_immutables
+    - avoid_unnecessary_containers
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+analyzer:
+  errors:
+    avoid_hard_coded_colors: warning

--- a/lib/core/constants/radii.dart
+++ b/lib/core/constants/radii.dart
@@ -1,0 +1,6 @@
+class AppRadii {
+  static const double r8 = 8;
+  static const double r12 = 12;
+  static const double r16 = 16;
+  static const double r24 = 24;
+}

--- a/lib/core/constants/spacing.dart
+++ b/lib/core/constants/spacing.dart
@@ -1,0 +1,8 @@
+class AppSpacing {
+  static const double s4 = 4;
+  static const double s8 = 8;
+  static const double s12 = 12;
+  static const double s16 = 16;
+  static const double s24 = 24;
+  static const double s32 = 32;
+}

--- a/lib/core/constants/text_styles.dart
+++ b/lib/core/constants/text_styles.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/material.dart';
+
+class AppTextStyles {
+  static const headline = TextStyle(fontSize: 20, fontWeight: FontWeight.bold);
+  static const body = TextStyle(fontSize: 16);
+  static const caption = TextStyle(fontSize: 14, color: Color(0xFFB0B0B0));
+}

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -1,5 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import '../../core/constants/radii.dart';
+import '../../core/constants/spacing.dart';
+import '../../core/constants/text_styles.dart';
+import '../../widgets/app_button.dart';
 
 import '../../core/data/habit_repository.dart';
 import '../../core/data/models/habit.dart';
@@ -85,7 +89,7 @@ class _HomeScreenState extends State<HomeScreen> {
   void _showHabitOptions(Habit habit) {
     showModalBottomSheet<void>(
       context: context,
-      backgroundColor: const Color(0xFF1E1E1E),
+      backgroundColor: Theme.of(context).colorScheme.surfaceVariant,
       builder: (context) => SafeArea(
         child: ListTile(
           leading: const Icon(Icons.archive, color: Colors.white),
@@ -98,7 +102,6 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
     );
   }
-
 
   int _todayCount(String id) {
     final key = DateFormat('yyyy-MM-dd').format(DateTime.now().toUtc());
@@ -143,26 +146,32 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
-    const purple = Color(0xFF8A2BE2);
+    final scheme = Theme.of(context).colorScheme;
     return Scaffold(
-      backgroundColor: const Color(0xFF121212),
+      backgroundColor: scheme.background,
       appBar: AppBar(
-        backgroundColor: const Color(0xFF121212),
+        backgroundColor: scheme.background,
         elevation: 0,
         leading: IconButton(
           icon: const Icon(Icons.settings, color: Colors.white),
           onPressed: () => context.push('/settings'),
         ),
         title: RichText(
-          text: const TextSpan(
-            style: TextStyle(
+          text: TextSpan(
+            style: const TextStyle(
               fontWeight: FontWeight.bold,
               fontSize: 20,
               fontFamily: 'Roboto',
             ),
             children: [
-              TextSpan(text: 'Habit', style: TextStyle(color: Colors.white)),
-              TextSpan(text: 'Hero', style: TextStyle(color: purple)),
+              const TextSpan(
+                text: 'Habit',
+                style: TextStyle(color: Colors.white),
+              ),
+              TextSpan(
+                text: 'Hero',
+                style: TextStyle(color: scheme.primary),
+              ),
             ],
           ),
         ),
@@ -184,7 +193,7 @@ class _HomeScreenState extends State<HomeScreen> {
           if (habits.isEmpty) {
             return Center(
               child: Padding(
-                padding: const EdgeInsets.all(24),
+                padding: const EdgeInsets.all(AppSpacing.s24),
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
                   children: [
@@ -195,36 +204,31 @@ class _HomeScreenState extends State<HomeScreen> {
                         shape: BoxShape.circle,
                         color: Colors.white.withOpacity(0.1),
                       ),
-                      child: const Icon(Icons.add, color: Colors.white, size: 40),
-                    ),
-                    const SizedBox(height: 24),
-                    const Text(
-                      'No habit found',
-                      style: TextStyle(
+                      child: const Icon(
+                        Icons.add,
                         color: Colors.white,
-                        fontSize: 24,
-                        fontWeight: FontWeight.bold,
+                        size: 40,
                       ),
                     ),
-                    const SizedBox(height: 8),
+                    const SizedBox(height: AppSpacing.s24),
+                    Text(
+                      'No habit found',
+                      style: AppTextStyles.headline.copyWith(
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: AppSpacing.s8),
                     const Text(
                       'Create a new habit to track your progress',
                       textAlign: TextAlign.center,
-                      style: TextStyle(color: Colors.white70),
+                      style: AppTextStyles.caption,
                     ),
-                    const SizedBox(height: 32),
+                    const SizedBox(height: AppSpacing.s32),
                     SizedBox(
                       width: double.infinity,
-                      child: ElevatedButton(
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: purple,
-                          foregroundColor: Colors.white,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(30),
-                          ),
-                        ),
+                      child: AppButton(
+                        label: 'Get started',
                         onPressed: _goToAddHabit,
-                        child: const Text('Get started'),
                       ),
                     ),
                   ],
@@ -240,15 +244,17 @@ class _HomeScreenState extends State<HomeScreen> {
               children: [
                 if (context.watch<SettingsProvider>().showQuickStats)
                   const Padding(
-                    padding: EdgeInsets.only(bottom: 16),
+                    padding: EdgeInsets.only(bottom: AppSpacing.s16),
                     child: AnalyticsQuickRow(),
                   ),
                 for (final habit in habits)
                   HabitItemWidget(
                     habit: habit,
 
-                    completionMap:
-                        _completionData.putIfAbsent(habit.id, () => {}),
+                    completionMap: _completionData.putIfAbsent(
+                      habit.id,
+                      () => {},
+                    ),
                     todayCount: _todayCount(habit.id),
                     onIncrement: () => _incrementToday(habit.id),
                     onDecrement: () => _decrementToday(habit.id),
@@ -260,16 +266,17 @@ class _HomeScreenState extends State<HomeScreen> {
                     onLongPress: () => _showHabitOptions(habit),
 
                     onDayTapped: (day) {
-                      context.push('/calendar_edit', extra: {
-                        'habitId': habit.id,
-                        'habitName': habit.name,
-                        'completionMap': _completionData[habit.id],
-                      });
+                      context.push(
+                        '/calendar_edit',
+                        extra: {
+                          'habitId': habit.id,
+                          'habitName': habit.name,
+                          'completionMap': _completionData[habit.id],
+                        },
+                      );
                     },
-
                   ),
               ],
-
             ),
           );
         },

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import '../core/constants/radii.dart';
+import '../core/constants/spacing.dart';
+
+class AppButton extends StatelessWidget {
+  final String label;
+  final VoidCallback onPressed;
+  final bool primary;
+
+  const AppButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+    this.primary = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = primary
+        ? Theme.of(context).colorScheme.primary
+        : Theme.of(context).colorScheme.surfaceVariant;
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: color,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s32,
+          vertical: AppSpacing.s12,
+        ),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.r24),
+        ),
+      ),
+      onPressed: onPressed,
+      child: Text(label),
+    );
+  }
+}

--- a/lib/widgets/app_chip.dart
+++ b/lib/widgets/app_chip.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import '../core/constants/radii.dart';
+import '../core/constants/spacing.dart';
+
+class AppChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const AppChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.s12,
+          vertical: AppSpacing.s8,
+        ),
+        decoration: BoxDecoration(
+          color: selected
+              ? Theme.of(context).colorScheme.primary
+              : Theme.of(context).colorScheme.surfaceVariant,
+          borderRadius: BorderRadius.circular(AppRadii.r16),
+        ),
+        child: Text(
+          label,
+          style: TextStyle(
+            color: selected ? Colors.white : Colors.grey[300],
+            fontSize: 14,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/section_header.dart
+++ b/lib/widgets/section_header.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+import '../core/constants/spacing.dart';
+import '../core/constants/text_styles.dart';
+
+class SectionHeader extends StatelessWidget {
+  final String title;
+  const SectionHeader({super.key, required this.title});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.s16,
+        vertical: AppSpacing.s8,
+      ),
+      child: Text(title, style: AppTextStyles.headline),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add spacing, radii and text style constants
- create shared widgets: AppButton, AppChip, SectionHeader
- update Home screen to use new widgets and constants
- enable lint rules enforcing const usage and color scheme
- add screenshot QA checklist

## Testing
- `dart format lib/widgets/app_button.dart lib/widgets/app_chip.dart lib/widgets/section_header.dart lib/core/constants/spacing.dart lib/core/constants/radii.dart lib/core/constants/text_styles.dart lib/features/home/home_screen.dart`
- `flutter analyze` *(fails: 1566 issues)*

------
https://chatgpt.com/codex/tasks/task_e_6876462f39008329b901309545d7f190