### PR TITLE
Fix theme mode

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -8,6 +8,8 @@ import 'features/habits/category_creation_screen.dart';
 import 'features/habits/streak_goal_screen.dart';
 import 'features/habits/reminder_screen.dart';
 import 'core/data/models/habit.dart';
+import 'package:provider/provider.dart';
+import 'core/services/settings_provider.dart';
 
 /// Root app widget
 class App extends StatelessWidget {
@@ -18,31 +20,44 @@ class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final router = createRouter(onboardingComplete, navigatorKey);
+    final settings = context.watch<SettingsProvider>();
     final baseDark = ThemeData.dark();
+    final baseLight = ThemeData.light();
+
+    final darkTheme = ThemeData.dark().copyWith(
+      colorScheme: baseDark.colorScheme.copyWith(
+        primary: const Color(0xFF8A2BE2),
+        secondary: const Color(0xFF8A2BE2),
+      ),
+      scaffoldBackgroundColor: const Color(0xFF121212),
+      appBarTheme: const AppBarTheme(
+        backgroundColor: Color(0xFF121212),
+        elevation: 0,
+        iconTheme: IconThemeData(color: Colors.white),
+      ),
+      inputDecorationTheme: const InputDecorationTheme(
+        filled: true,
+        fillColor: Color(0xFF1E1E1E),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.all(Radius.circular(12)),
+          borderSide: BorderSide.none,
+        ),
+        hintStyle: TextStyle(color: Colors.white70),
+      ),
+    );
+
+    final lightTheme = ThemeData.light().copyWith(
+      colorScheme: baseLight.colorScheme.copyWith(
+        primary: const Color(0xFF8A2BE2),
+        secondary: const Color(0xFF8A2BE2),
+      ),
+    );
+
     return MaterialApp.router(
       title: 'Habit Tracker',
-      themeMode: ThemeMode.dark,
-      theme: ThemeData.dark().copyWith(
-        colorScheme: baseDark.colorScheme.copyWith(
-          primary: const Color(0xFF8A2BE2),
-          secondary: const Color(0xFF8A2BE2),
-        ),
-        scaffoldBackgroundColor: const Color(0xFF121212),
-        appBarTheme: const AppBarTheme(
-          backgroundColor: Color(0xFF121212),
-          elevation: 0,
-          iconTheme: IconThemeData(color: Colors.white),
-        ),
-        inputDecorationTheme: const InputDecorationTheme(
-          filled: true,
-          fillColor: Color(0xFF1E1E1E),
-          border: OutlineInputBorder(
-            borderRadius: BorderRadius.all(Radius.circular(12)),
-            borderSide: BorderSide.none,
-          ),
-          hintStyle: TextStyle(color: Colors.white70),
-        ),
-      ),
+      themeMode: settings.themeMode,
+      theme: lightTheme,
+      darkTheme: darkTheme,
       routerConfig: router,
     );
   }

--- a/lib/core/services/settings_provider.dart
+++ b/lib/core/services/settings_provider.dart
@@ -8,8 +8,10 @@ class SettingsProvider extends ChangeNotifier {
   final SharedPreferences _prefs;
 
   static const _keyShowQuick = 'show_quick_stats';
+  static const _keyThemeMode = 'theme_mode';
 
   bool _showQuickStats = true;
+  ThemeMode _themeMode = ThemeMode.system;
 
   /// Whether quick stats row is visible on the home screen.
   bool get showQuickStats => _showQuickStats;
@@ -17,6 +19,12 @@ class SettingsProvider extends ChangeNotifier {
   /// Loads persisted settings.
   void load() {
     _showQuickStats = _prefs.getBool(_keyShowQuick) ?? true;
+    final modeIndex = _prefs.getInt(_keyThemeMode);
+    if (modeIndex != null &&
+        modeIndex >= 0 &&
+        modeIndex < ThemeMode.values.length) {
+      _themeMode = ThemeMode.values[modeIndex];
+    }
     notifyListeners();
   }
 
@@ -24,6 +32,16 @@ class SettingsProvider extends ChangeNotifier {
   Future<void> setShowQuickStats(bool value) async {
     _showQuickStats = value;
     await _prefs.setBool(_keyShowQuick, value);
+    notifyListeners();
+  }
+
+  /// Current theme mode used by the application.
+  ThemeMode get themeMode => _themeMode;
+
+  /// Persists and updates the theme mode.
+  Future<void> setThemeMode(ThemeMode mode) async {
+    _themeMode = mode;
+    await _prefs.setInt(_keyThemeMode, mode.index);
     notifyListeners();
   }
 }

--- a/lib/features/settings/theme_screen.dart
+++ b/lib/features/settings/theme_screen.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../core/services/settings_provider.dart';
 
 /// Simple theme selection screen placeholder.
 class ThemeScreen extends StatefulWidget {
@@ -9,45 +12,43 @@ class ThemeScreen extends StatefulWidget {
 }
 
 class _ThemeScreenState extends State<ThemeScreen> {
-  ThemeMode _mode = ThemeMode.system;
-
   void _setMode(ThemeMode? mode) {
     if (mode == null) return;
-    setState(() => _mode = mode);
+    context.read<SettingsProvider>().setThemeMode(mode);
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF121212),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       appBar: AppBar(
         title: const Text('Theme'),
         leading: IconButton(
           icon: const Icon(Icons.arrow_back, color: Colors.white),
           onPressed: () => Navigator.pop(context),
         ),
-        backgroundColor: const Color(0xFF121212),
+        backgroundColor: Theme.of(context).scaffoldBackgroundColor,
         elevation: 0,
       ),
       body: Column(
         children: [
           RadioListTile<ThemeMode>(
             value: ThemeMode.system,
-            groupValue: _mode,
+            groupValue: context.watch<SettingsProvider>().themeMode,
             onChanged: _setMode,
             activeColor: Colors.white,
             title: const Text('System', style: TextStyle(color: Colors.white)),
           ),
           RadioListTile<ThemeMode>(
             value: ThemeMode.light,
-            groupValue: _mode,
+            groupValue: context.watch<SettingsProvider>().themeMode,
             onChanged: _setMode,
             activeColor: Colors.white,
             title: const Text('Light', style: TextStyle(color: Colors.white)),
           ),
           RadioListTile<ThemeMode>(
             value: ThemeMode.dark,
-            groupValue: _mode,
+            groupValue: context.watch<SettingsProvider>().themeMode,
             onChanged: _setMode,
             activeColor: Colors.white,
             title: const Text('Dark', style: TextStyle(color: Colors.white)),

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -12,7 +12,12 @@ import 'package:habit_hero_project/app.dart';
 
 void main() {
   testWidgets('App builds', (WidgetTester tester) async {
-    await tester.pumpWidget(const App(onboardingComplete: false));
+    await tester.pumpWidget(
+      App(
+        onboardingComplete: false,
+        navigatorKey: GlobalKey<NavigatorState>(),
+      ),
+    );
     expect(find.byType(MaterialApp), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add theme mode preference support
- allow user to change theme in settings
- persist theme mode in settings provider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764a2035a0832999e2badce4eac22a