### PR TITLE
Fix default tracking type for new habits

### DIFF
--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -105,6 +105,9 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
       _categories = List.of(habit.categories);
       _trackingType = habit.completionTrackingType;
       _completionTarget = habit.completionTarget;
+    } else {
+      _trackingType = CompletionTrackingType.stepByStep;
+      _completionTarget = 1;
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure Add/Edit Habit screen initializes with step-by-step tracking

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764a243c50832997c3788ed0cea798