### PR TITLE
Enable back navigation on analytics and backup screens

### DIFF
--- a/lib/features/analytics/analytics_screen.dart
+++ b/lib/features/analytics/analytics_screen.dart
@@ -34,7 +34,13 @@ class _AnalyticsScreenState extends State<AnalyticsScreen> {
 
     return Scaffold(
       backgroundColor: const Color(0xFF121212),
-      appBar: AppBar(title: const Text('Analytics')),
+      appBar: AppBar(
+        title: const Text('Analytics'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
       body: Column(
         children: [
           const SizedBox(height: 16),

--- a/lib/features/export_import/export_import_screen.dart
+++ b/lib/features/export_import/export_import_screen.dart
@@ -84,6 +84,10 @@ class _ExportImportScreenState extends State<ExportImportScreen> {
       backgroundColor: const Color(0xFF121212),
       appBar: AppBar(
         title: const Text('Backup & Restore'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back, color: Colors.white),
+          onPressed: () => Navigator.pop(context),
+        ),
         backgroundColor: const Color(0xFF121212),
       ),
       body: Padding(

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -178,7 +178,7 @@ class _HomeScreenState extends State<HomeScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.bar_chart, color: Colors.white),
-            onPressed: () => context.go('/analytics'),
+            onPressed: () => context.push('/analytics'),
           ),
           IconButton(
             icon: const Icon(Icons.add_circle_outline, color: Colors.white),

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -44,7 +44,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
             subtitle: const Text('Export or import your data',
                 style: TextStyle(color: Color(0xFFB0B0B0))),
             trailing: const Icon(Icons.chevron_right, color: Colors.white),
-            onTap: () => context.go('/backup_restore'),
+            onTap: () => context.push('/backup_restore'),
           ),
           const Divider(color: Color(0xFF2A2A2A)),
           ListTile(


### PR DESCRIPTION
## Summary
- enable pushing to analytics and backup screens
- add back buttons to the analytics and backup/restore app bars

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764a25b1088329bae3cc3629f11660