### PR TITLE
Add single vs multiple completion habits

### DIFF
--- a/lib/core/data/models/habit.dart
+++ b/lib/core/data/models/habit.dart
@@ -22,6 +22,7 @@ class Habit {
     this.categories = const [],
     this.completionTrackingType = CompletionTrackingType.stepByStep,
     this.completionTarget = 1,
+    this.isMultiple = false,
   });
 
   /// Unique identifier for the habit.
@@ -63,6 +64,9 @@ class Habit {
   /// Target value per day when using [CompletionTrackingType.customValue].
   int completionTarget;
 
+  /// Whether this habit can be completed multiple times per day.
+  bool isMultiple;
+
   /// Serializes this habit to a map.
   Map<String, dynamic> toMap() => {
         'id': id,
@@ -81,6 +85,7 @@ class Habit {
         'categories': categories,
         'completionTrackingType': completionTrackingType.index,
         'completionTarget': completionTarget,
+        'isMultiple': isMultiple,
       };
 
   /// Converts this habit to JSON.
@@ -107,6 +112,7 @@ class Habit {
         completionTrackingType: CompletionTrackingType
             .values[map['completionTrackingType'] as int? ?? 0],
         completionTarget: map['completionTarget'] as int? ?? 1,
+        isMultiple: map['isMultiple'] as bool? ?? false,
       );
 
   /// Creates a habit from JSON string.
@@ -127,6 +133,7 @@ class Habit {
     List<String>? categories,
     CompletionTrackingType? completionTrackingType,
     int? completionTarget,
+    bool? isMultiple,
   }) =>
       Habit(
         id: id ?? this.id,
@@ -142,5 +149,6 @@ class Habit {
         completionTrackingType:
             completionTrackingType ?? this.completionTrackingType,
         completionTarget: completionTarget ?? this.completionTarget,
+        isMultiple: isMultiple ?? this.isMultiple,
       );
 }

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -39,6 +39,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
   List<String> _categories = [];
   CompletionTrackingType _trackingType = CompletionTrackingType.stepByStep;
   int _completionTarget = 1;
+  bool _isMultiple = false;
 
   static const List<String> _allCategories = [
     'Art',
@@ -105,9 +106,11 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
       _categories = List.of(habit.categories);
       _trackingType = habit.completionTrackingType;
       _completionTarget = habit.completionTarget;
+      _isMultiple = habit.isMultiple;
     } else {
       _trackingType = CompletionTrackingType.stepByStep;
       _completionTarget = 1;
+      _isMultiple = false;
     }
   }
 
@@ -187,6 +190,10 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
   Future<void> _save() async {
     final name = _nameController.text.trim();
     if (name.isEmpty) return;
+    if (!_isMultiple) {
+      _trackingType = CompletionTrackingType.customValue;
+      _completionTarget = 1;
+    }
     final habit = Habit(
       id: widget.habit?.id ?? const Uuid().v4(),
       name: name,
@@ -200,6 +207,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
       categories: _categories,
       completionTrackingType: _trackingType,
       completionTarget: _completionTarget,
+      isMultiple: _isMultiple,
     );
     if (_isEditing) {
       await HabitRepository.updateHabit(habit);
@@ -440,24 +448,47 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
           children: [
             Expanded(
               child: ChoiceChip(
-                label: const Text('Step By Step'),
-                selected: _trackingType == CompletionTrackingType.stepByStep,
-                onSelected: (_) => setState(
-                    () => _trackingType = CompletionTrackingType.stepByStep),
+                label: const Text('Single'),
+                selected: !_isMultiple,
+                onSelected: (_) => setState(() => _isMultiple = false),
               ),
             ),
             const SizedBox(width: 8),
             Expanded(
               child: ChoiceChip(
-                label: const Text('Custom Value'),
-                selected: _trackingType == CompletionTrackingType.customValue,
-                onSelected: (_) => setState(
-                    () => _trackingType = CompletionTrackingType.customValue),
+                label: const Text('Multiple'),
+                selected: _isMultiple,
+                onSelected: (_) => setState(() => _isMultiple = true),
               ),
             ),
           ],
         ),
-        if (_trackingType == CompletionTrackingType.customValue) ...[
+        if (_isMultiple) ...[
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: ChoiceChip(
+                  label: const Text('Step By Step'),
+                  selected: _trackingType == CompletionTrackingType.stepByStep,
+                  onSelected: (_) => setState(
+                      () => _trackingType = CompletionTrackingType.stepByStep),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: ChoiceChip(
+                  label: const Text('Custom Value'),
+                  selected: _trackingType == CompletionTrackingType.customValue,
+                  onSelected: (_) => setState(
+                      () => _trackingType = CompletionTrackingType.customValue),
+                ),
+              ),
+            ],
+          ),
+        ],
+        if (_isMultiple &&
+            _trackingType == CompletionTrackingType.customValue) ...[
           const SizedBox(height: 8),
           Row(
             children: [

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -116,18 +116,32 @@ class HabitItemWidget extends StatelessWidget {
               Row(
                 children: [
                   IconButton(
-                    icon: const Icon(Icons.remove, color: Colors.white),
-                    onPressed: todayCount > 0 ? onDecrement : null,
+                    icon: Icon(
+                      habit.isMultiple
+                          ? Icons.check_box
+                          : (todayCount > 0
+                              ? Icons.check_box
+                              : Icons.check_box_outline_blank),
+                      color: Colors.white,
+                    ),
+                    onPressed: () {
+                      if (habit.isMultiple) {
+                        onIncrement();
+                      } else {
+                        if (todayCount > 0) {
+                          onDecrement();
+                        } else {
+                          onIncrement();
+                        }
+                      }
+                    },
                   ),
-                  Text(
-                    '$todayCount',
-                    style:
-                        const TextStyle(color: Colors.white, fontSize: 16),
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.add, color: Colors.white),
-                    onPressed: onIncrement,
-                  ),
+                  if (habit.isMultiple)
+                    Text(
+                      '$todayCount',
+                      style:
+                          const TextStyle(color: Colors.white, fontSize: 16),
+                    ),
                 ],
               ),
               if (onEdit != null)

--- a/test/multiple_completion_test.dart
+++ b/test/multiple_completion_test.dart
@@ -14,7 +14,12 @@ void main() {
 
   test('increment and decrement today count', () async {
     final repo = CompletionRepository();
-    final habit = Habit(id: 'h1', name: 'Water', completionTarget: 8);
+    final habit = Habit(
+      id: 'h1',
+      name: 'Water',
+      completionTarget: 8,
+      isMultiple: true,
+    );
     await HabitRepository.addHabit(habit);
 
     await repo.incrementToday(habit.id);


### PR DESCRIPTION
## Summary
- allow marking habits as single or multiple completion
- store the option in `Habit`
- update habit creation UI with toggle for single/multiple
- display check mark button for completion and count when multiple
- adjust completion tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68764da0acf48329b206e6e8a86d135d