### PR TITLE
Allow choosing export location

### DIFF
--- a/lib/core/services/export_import_service.dart
+++ b/lib/core/services/export_import_service.dart
@@ -31,8 +31,8 @@ class ExportImportService {
   }
 
   /// Export all habits and completions to a JSON file.
-  Future<File> exportToJson() async {
-    final dir = await _documentsDir();
+  Future<File> exportToJson([Directory? directory]) async {
+    final dir = directory ?? await _documentsDir();
     final habits = await HabitRepository.loadHabits();
     final completionData = <String, List<String>>{};
     for (final h in habits) {
@@ -48,8 +48,8 @@ class ExportImportService {
   }
 
   /// Export all habits and completions to a CSV file.
-  Future<File> exportToCsv() async {
-    final dir = await _documentsDir();
+  Future<File> exportToCsv([Directory? directory]) async {
+    final dir = directory ?? await _documentsDir();
     final habits = await HabitRepository.loadHabits();
     final rows = <List<dynamic>>[
       ['habitId', 'habitName', 'date', 'count'],

--- a/lib/features/export_import/export_import_screen.dart
+++ b/lib/features/export_import/export_import_screen.dart
@@ -17,12 +17,14 @@ class _ExportImportScreenState extends State<ExportImportScreen> {
   final ExportImportService _service = GetIt.I<ExportImportService>();
 
   Future<void> _exportJson() async {
+    final path = await FilePicker.platform.getDirectoryPath();
+    if (path == null) return;
     final messenger = ScaffoldMessenger.of(context);
     messenger
       ..hideCurrentSnackBar()
       ..showSnackBar(const SnackBar(content: Text('Exporting...')));
     try {
-      final file = await _service.exportToJson();
+      final file = await _service.exportToJson(Directory(path));
       messenger
         ..hideCurrentSnackBar()
         ..showSnackBar(SnackBar(content: Text('Export saved to ${file.path}')));
@@ -34,12 +36,14 @@ class _ExportImportScreenState extends State<ExportImportScreen> {
   }
 
   Future<void> _exportCsv() async {
+    final path = await FilePicker.platform.getDirectoryPath();
+    if (path == null) return;
     final messenger = ScaffoldMessenger.of(context);
     messenger
       ..hideCurrentSnackBar()
       ..showSnackBar(const SnackBar(content: Text('Exporting...')));
     try {
-      final file = await _service.exportToCsv();
+      final file = await _service.exportToCsv(Directory(path));
       messenger
         ..hideCurrentSnackBar()
         ..showSnackBar(SnackBar(content: Text('Export saved to ${file.path}')));


### PR DESCRIPTION
## Summary
- let user select directory before exporting data
- support optional directory in export service API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687650123520832996c6a337c962b633