### PR TITLE
Fix analyzer errors

### DIFF
--- a/lib/features/analytics/analytics_quick_row.dart
+++ b/lib/features/analytics/analytics_quick_row.dart
@@ -18,14 +18,14 @@ class AnalyticsQuickRow extends StatelessWidget {
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
-        _chip('Today', '$todayCount / $totalHabits'),
-        _chip('7-Day', '${overall.sevenDaySuccessRate.toStringAsFixed(0)} %'),
-        _chip('Longest Streak', '${overall.longestStreak} days'),
+        _chip(context, 'Today', '$todayCount / $totalHabits'),
+        _chip(context, '7-Day', '${overall.sevenDaySuccessRate.toStringAsFixed(0)} %'),
+        _chip(context, 'Longest Streak', '${overall.longestStreak} days'),
       ],
     );
   }
 
-  Widget _chip(String label, String value) {
+  Widget _chip(BuildContext context, String label, String value) {
     final scheme = Theme.of(context).colorScheme;
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -121,29 +121,13 @@ class HabitItemWidget extends StatelessWidget {
               Row(
                 children: [
                   IconButton(
-
-                    icon: Icon(Icons.remove,
-                        color: Theme.of(context).colorScheme.onBackground),
-                    onPressed: todayCount > 0 ? onDecrement : null,
-                  ),
-                  Text(
-                    '$todayCount',
-                    style: TextStyle(
-                        color: Theme.of(context).colorScheme.onBackground,
-                        fontSize: 16),
-                  ),
-                  IconButton(
-                    icon: Icon(Icons.add,
-                        color: Theme.of(context).colorScheme.onBackground),
-                    onPressed: onIncrement,
-
                     icon: Icon(
                       habit.isMultiple
                           ? Icons.check_box
                           : (todayCount > 0
                               ? Icons.check_box
                               : Icons.check_box_outline_blank),
-                      color: Colors.white,
+                      color: Theme.of(context).colorScheme.onBackground,
                     ),
                     onPressed: () {
                       if (habit.isMultiple) {
@@ -156,13 +140,13 @@ class HabitItemWidget extends StatelessWidget {
                         }
                       }
                     },
-
                   ),
                   if (habit.isMultiple)
                     Text(
                       '$todayCount',
-                      style:
-                          const TextStyle(color: Colors.white, fontSize: 16),
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.onBackground,
+                          fontSize: 16),
                     ),
                 ],
               ),

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -87,6 +87,7 @@ class _HomeScreenState extends State<HomeScreen> {
   }
 
   void _showHabitOptions(Habit habit) {
+    final scheme = Theme.of(context).colorScheme;
     showModalBottomSheet<void>(
       context: context,
       backgroundColor: Theme.of(context).colorScheme.surfaceVariant,


### PR DESCRIPTION
## Summary
- pass BuildContext to `_chip` in `AnalyticsQuickRow`
- simplify habit row toggle logic and remove duplicate parameters
- initialize color scheme in `HomeScreen._showHabitOptions`

## Testing
- `apt-get install snapd` *(fails: flutter tool not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6876524f6c988329b36adcec73806f01