### PR TITLE
Fix IconData tree shaking issue

### DIFF
--- a/lib/core/constants/icon_mapping.dart
+++ b/lib/core/constants/icon_mapping.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+
+/// Mapping of icon code points to constant [IconData] instances.
+///
+/// Using this map allows the app to reference icons without invoking
+/// the [IconData] constructor at runtime, enabling tree shaking of the
+/// Material icon font.
+const Map<int, IconData> kIconMap = {
+  Icons.star_border.codePoint: Icons.star_border,
+  Icons.favorite_border.codePoint: Icons.favorite_border,
+  Icons.run_circle_outlined.codePoint: Icons.run_circle_outlined,
+  Icons.book_outlined.codePoint: Icons.book_outlined,
+  Icons.fitness_center.codePoint: Icons.fitness_center,
+  Icons.savings_outlined.codePoint: Icons.savings_outlined,
+  Icons.school_outlined.codePoint: Icons.school_outlined,
+  Icons.self_improvement.codePoint: Icons.self_improvement,
+  Icons.work_outline.codePoint: Icons.work_outline,
+  Icons.music_note.codePoint: Icons.music_note,
+  Icons.food_bank_outlined.codePoint: Icons.food_bank_outlined,
+  Icons.water_drop_outlined.codePoint: Icons.water_drop_outlined,
+  Icons.timer_outlined.codePoint: Icons.timer_outlined,
+  Icons.mood_outlined.codePoint: Icons.mood_outlined,
+  Icons.code.codePoint: Icons.code,
+  // Icons referenced in templates.
+  Icons.book_online.codePoint: Icons.book_online,
+  Icons.access_alarm.codePoint: Icons.access_alarm,
+  Icons.account_box.codePoint: Icons.account_box,
+};
+
+/// Returns a constant [IconData] for the given [codePoint].
+///
+/// If the [codePoint] is not found in [kIconMap], a fallback icon is
+/// returned to avoid instantiating [IconData] at runtime.
+IconData iconFromCodePoint(int codePoint) =>
+    kIconMap[codePoint] ?? Icons.help_outline;
+

--- a/lib/core/data/models/badge.dart
+++ b/lib/core/data/models/badge.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import '../../constants/icon_mapping.dart';
 
 /// Model representing an achievement badge.
 class Badge {
@@ -27,7 +28,7 @@ class Badge {
   factory Badge.fromMap(Map<String, dynamic> map) => Badge(
         id: map['id'] as String,
         title: map['title'] as String,
-        icon: IconData(map['icon'] as int, fontFamily: 'MaterialIcons'),
+        icon: iconFromCodePoint(map['icon'] as int),
         awardedAt: DateTime.parse(map['awardedAt'] as String),
       );
 

--- a/lib/features/archive/archive_screen.dart
+++ b/lib/features/archive/archive_screen.dart
@@ -3,6 +3,7 @@ import '../../core/data/habit_repository.dart';
 import '../../core/data/models/habit.dart';
 import 'package:get_it/get_it.dart';
 import '../../core/services/notification_service.dart';
+import '../../core/constants/icon_mapping.dart';
 
 class ArchiveScreen extends StatefulWidget {
   const ArchiveScreen({super.key});
@@ -75,8 +76,7 @@ class _ArchiveScreenState extends State<ArchiveScreen> {
               itemCount: habits.length,
               itemBuilder: (context, index) {
                 final habit = habits[index];
-                final icon =
-                    IconData(habit.iconData, fontFamily: 'MaterialIcons');
+                final icon = iconFromCodePoint(habit.iconData);
                 return ListTile(
                   leading: Icon(icon, color: scheme.onBackground),
                   title: Text(habit.name,

--- a/lib/features/habits/add_edit_habit_screen.dart
+++ b/lib/features/habits/add_edit_habit_screen.dart
@@ -10,6 +10,7 @@ import 'package:get_it/get_it.dart';
 import '../../core/services/notification_service.dart';
 import '../../core/services/notification_permission_service.dart';
 import '../../core/data/models/habit_template.dart';
+import '../../core/constants/icon_mapping.dart';
 
 /// Screen for creating or editing a habit.
 class AddEditHabitScreen extends StatefulWidget {
@@ -98,7 +99,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
     _descriptionController =
         TextEditingController(text: habit?.description ?? '');
     if (habit != null) {
-      _icon = IconData(habit.iconData, fontFamily: 'MaterialIcons');
+      _icon = iconFromCodePoint(habit.iconData);
       _color = habit.color;
       _streakGoal = habit.streakGoal;
       _reminderTime = habit.reminderTime;
@@ -262,8 +263,7 @@ class _AddEditHabitScreenState extends State<AddEditHabitScreen> {
                     setState(() {
                       _nameController.text = tpl.name;
                       _descriptionController.text = tpl.description;
-                      _icon =
-                          IconData(tpl.iconData, fontFamily: 'MaterialIcons');
+                      _icon = iconFromCodePoint(tpl.iconData);
                       _color = tpl.color;
                       _reminderTime = tpl.reminderTime;
                       _reminderWeekdays = tpl.reminderWeekdays;

--- a/lib/features/habits/habit_item_widget.dart
+++ b/lib/features/habits/habit_item_widget.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/data/models/habit.dart';
 import '../dashboard/heatmap_widget.dart';
+import '../../core/constants/icon_mapping.dart';
 
 /// List item widget displaying a habit with its current streak.
 class HabitItemWidget extends StatelessWidget {
@@ -51,7 +52,7 @@ class HabitItemWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scheme = Theme.of(context).colorScheme;
-    final icon = IconData(habit.iconData, fontFamily: 'MaterialIcons');
+    final icon = iconFromCodePoint(habit.iconData);
     final showBadge = currentStreak != null &&
         (currentStreak == 7 || currentStreak == 30 || currentStreak == 100);
 

--- a/lib/features/templates/template_gallery_screen.dart
+++ b/lib/features/templates/template_gallery_screen.dart
@@ -6,6 +6,7 @@ import '../../core/constants/text_styles.dart';
 import '../../core/services/template_service.dart';
 import '../../core/data/models/habit_template.dart';
 import '../../widgets/app_button.dart';
+import '../../core/constants/icon_mapping.dart';
 
 class TemplateGalleryScreen extends StatelessWidget {
   const TemplateGalleryScreen({super.key});
@@ -54,7 +55,7 @@ class TemplateGalleryScreen extends StatelessWidget {
                         radius: 24,
                         backgroundColor: Color(tpl.color),
                         child: Icon(
-                          IconData(tpl.iconData, fontFamily: 'MaterialIcons'),
+                          iconFromCodePoint(tpl.iconData),
                           color: scheme.onPrimary,
                         ),
                       ),


### PR DESCRIPTION
## Summary
- replace dynamic `IconData` creation with constant icon map
- add `iconFromCodePoint` helper
- use icon mapping across feature screens and models

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68765472578c8329a41733ca85248714