### PR TITLE
Add storage permission service

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <application
         android:label="habit_hero_project"
         android:name="${applicationName}"

--- a/lib/core/services/di.dart
+++ b/lib/core/services/di.dart
@@ -11,6 +11,7 @@ import 'settings_provider.dart';
 import 'template_service.dart';
 
 import 'notification_permission_service.dart';
+import 'storage_permission_service.dart';
 
 /// Registers app services in the provided [getIt] instance.
 void registerServices(GetIt getIt, SharedPreferences prefs) {
@@ -21,6 +22,8 @@ void registerServices(GetIt getIt, SharedPreferences prefs) {
 
   getIt.registerLazySingleton<NotificationPermissionService>(
       () => NotificationPermissionService(prefs));
+  getIt.registerLazySingleton<StoragePermissionService>(
+      () => StoragePermissionService());
 
   getIt.registerLazySingleton<AnalyticsService>(() => AnalyticsService(
       getIt<HabitRepository>(), getIt<CompletionRepository>()));

--- a/lib/core/services/storage_permission_service.dart
+++ b/lib/core/services/storage_permission_service.dart
@@ -1,0 +1,8 @@
+import 'package:permission_handler/permission_handler.dart';
+
+class StoragePermissionService {
+  Future<void> ensureStoragePermission() async {
+    if (await Permission.storage.isGranted) return;
+    await Permission.storage.request();
+  }
+}

--- a/lib/features/export_import/export_import_screen.dart
+++ b/lib/features/export_import/export_import_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:file_picker/file_picker.dart';
+import '../../core/services/storage_permission_service.dart';
 
 import '../../core/services/export_import_service.dart';
 
@@ -15,8 +16,11 @@ class ExportImportScreen extends StatefulWidget {
 
 class _ExportImportScreenState extends State<ExportImportScreen> {
   final ExportImportService _service = GetIt.I<ExportImportService>();
+  final StoragePermissionService _permService =
+      GetIt.I<StoragePermissionService>();
 
   Future<void> _exportJson() async {
+    await _permService.ensureStoragePermission();
     final path = await FilePicker.platform.getDirectoryPath();
     if (path == null) return;
     final messenger = ScaffoldMessenger.of(context);
@@ -36,6 +40,7 @@ class _ExportImportScreenState extends State<ExportImportScreen> {
   }
 
   Future<void> _exportCsv() async {
+    await _permService.ensureStoragePermission();
     final path = await FilePicker.platform.getDirectoryPath();
     if (path == null) return;
     final messenger = ScaffoldMessenger.of(context);
@@ -55,6 +60,7 @@ class _ExportImportScreenState extends State<ExportImportScreen> {
   }
 
   Future<void> _importFile() async {
+    await _permService.ensureStoragePermission();
     final result = await FilePicker.platform.pickFiles(
       type: FileType.custom,
       allowedExtensions: ['json', 'csv'],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   provider: ^6.0.5
   fl_chart: ^0.65.0
   intl: ^0.20.2
+  permission_handler: ^12.0.1
 
 
 dev_dependencies:


### PR DESCRIPTION
## Summary
- request storage permission at runtime
- wire up new service in dependency injection
- update export/import screen to ask for permission
- declare storage permissions in Android manifest
- add `permission_handler` dependency

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687657a4c4bc8329830a2faa8835966f