### PR TITLE
Fix Android notification permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <!-- Required for posting notifications on Android 13+ -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
     <application
         android:label="habit_hero_project"
         android:name="${applicationName}"


### PR DESCRIPTION
## Summary
- add `POST_NOTIFICATIONS` permission on Android

## Testing
- `flutter test -r expanded` *(fails: ProviderNotFoundException in widget tests)*

------
https://chatgpt.com/codex/tasks/task_e_68765a793b348329aa27599078d91104