### PR TITLE
Fix dotenv init for feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
 
+## Configuration
+
+Create a `.env` file in the project root with the Airtable credentials. An
+example is provided in `.env.example`.
+
 ## Screenshot QA Checklist
 - [ ] Light mode
 - [ ] Dark mode

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get_it/get_it.dart';
 import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:provider/provider.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'app.dart';
 import 'core/data/completion_repository.dart';
 import 'core/data/habit_repository.dart';
@@ -14,6 +15,7 @@ import 'core/services/settings_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
   final getIt = GetIt.instance;
   getIt.registerLazySingleton<HabitRepository>(() => HabitRepository());
   getIt.registerLazySingleton<CompletionRepository>(() => CompletionRepository());


### PR DESCRIPTION
## Summary
- load environment variables from `.env` at startup
- document env setup in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68789ee53390832993260c08f0df244d