### PR TITLE
Implement dotenv fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ samples, guidance on mobile development, and a full API reference.
 ## Configuration
 
 Create a `.env` file in the project root with the Airtable credentials. An
-example is provided in `.env.example`.
+example is provided in `.env.example`. If `.env` does not exist, the
+application will automatically fall back to `.env.example`.
 
 ## Screenshot QA Checklist
 - [ ] Light mode

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'dart:io';
 import 'app.dart';
 import 'core/data/completion_repository.dart';
 import 'core/data/habit_repository.dart';
@@ -15,7 +16,12 @@ import 'core/services/settings_provider.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await dotenv.load(fileName: '.env');
+  final envFile = File('.env');
+  if (envFile.existsSync()) {
+    await dotenv.load(fileName: '.env');
+  } else {
+    await dotenv.load(fileName: '.env.example');
+  }
   final getIt = GetIt.instance;
   getIt.registerLazySingleton<HabitRepository>(() => HabitRepository());
   getIt.registerLazySingleton<CompletionRepository>(() => CompletionRepository());


### PR DESCRIPTION
## Summary
- use `.env.example` when `.env` is missing
- document fallback behavior in README

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_68789f8e793c83299feab00e4de18892